### PR TITLE
BibFormat: updates the escaping policy

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_abstract.py
+++ b/bibformat/format_elements/bfe_INSPIRE_abstract.py
@@ -20,7 +20,7 @@
 """
 
 
-def format_element(bfo, prefix_en, suffix_en, escape="3", separator_en="<br/>"):
+def format_element(bfo, prefix_en, suffix_en, escape="0", separator_en="<br/>"):
     """ Prints the abstract of a record in HTML in English.
 
     @param prefix_en: a prefix for english abstract (printed only if english abstract exists)

--- a/bibformat/format_elements/bfe_INSPIRE_title_brief.py
+++ b/bibformat/format_elements/bfe_INSPIRE_title_brief.py
@@ -20,7 +20,7 @@
 """
 
 
-def format_element(bfo, highlight="no", force_title_case="no", brief="no", esctitle='1', oldtitles="no"):
+def format_element(bfo, highlight="no", force_title_case="no", brief="no", esctitle='0', oldtitles="no"):
     """
     Prints a title, with optional subtitles, and optional highlighting.
 


### PR DESCRIPTION
- Does not escape the title and abstract fields.

Signed-off by: Georgios Papoutsakisgeorgios.papoutsakis@cern.ch
