### PR TITLE
WebHelp: validation fixes and add link to FAQ

### DIFF
--- a/webhelp/help-central.webdoc
+++ b/webhelp/help-central.webdoc
@@ -53,6 +53,7 @@
       <en>
 	SPIRES-style easy search for <CFG_SITE_NAME_INTL>.
       </en>
+    </lang>
 </dd>
 
 <dt><a href="search-tips<lang:link/>">_(Search tips for INSPIRE)_</a></dt>
@@ -61,6 +62,7 @@
 	Tips for <CFG_SITE_NAME_INTL>, particularly for those familiar
 	with SPIRES.
       </en>
+    </lang>
 </dd>
 
 <dt><a href="invenio-search-tips<lang:link/>">_(Invenio Search Tips)_</a></dt>
@@ -122,7 +124,7 @@
       <hu>Teljes útmutató a <CFG_SITE_NAME_INTL> weboldalán való kereséshez.</hu>
     </lang>
 </dd>
-<dt><a href="/info/hep/additions"<lang:link/>">_(Additions)_</a>
+<dt><a href="/info/hep/additions<lang:link/>">_(Additions)_</a>
 </dt>
 <dd><lang>
       <en>How to request that we add documents to <CFG_SITE_NAME_INTL>.</en>
@@ -140,6 +142,12 @@
       <en>
        Full guide to system-generated citation metrics.
       </en>
+    </lang>
+</dd>
+<dt><a href="/info/faq/general<lang:link/>">_(FAQ)_</a></dt>
+<dd><lang>
+      <en>Frequently asked questions for <CFG_SITE_NAME_INTL></en>
+      <de>Häufig gestellte Fragen zur <CFG_SITE_NAME_INTL></de>
     </lang>
 </dd>
 </dl>


### PR DESCRIPTION
html fixes  -- missing </lang> tags makes languages not present miss display elements in firefox
adding a link to the FAQ
