### PR TITLE
BibFormat: additions to the HepNames HD display

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_Hepnames_Arxiv_BAI.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hepnames_Arxiv_BAI.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""BibFormat element - Prints arXiv BAI hotlink
+"""
+
+def format_element(bfo):
+    """
+    Provides HepNames detailed BFT with an arXiv author ID url
+    using 035__a if 035__9 is arxiv.
+    """
+
+    # base URL for arXiv author pages
+    ARXIVAU = 'http://arxiv.org/a'
+
+    bai = bfo.fields('035__')
+
+    for item in bai:
+        if item.get('9') and item['9'].lower() == 'arxiv' and item.get('a'):
+            return '<a href="%s/%s">%s</a>' % (ARXIVAU, item['a'], item['a'])
+
+# pylint: disable=W0613
+def escape_values(bfo):
+    """
+    Called by BibFormat in order to check if output of this element
+    should be escaped.
+    """
+
+    return 0
+# pylint: enable=W0613

--- a/bibformat/format_elements/bfe_INSPIRE_Hepnames_Arxiv_BAI_unit_test.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hepnames_Arxiv_BAI_unit_test.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import unittest
+from invenio.testutils import make_test_suite, \
+    run_test_suite
+from invenio.bibformat_engine import BibFormatObject
+from invenio.bibformat_elements import bfe_INSPIRE_Hepnames_Arxiv_BAI
+
+TESTREC1 = """<collection><record><controlfield tag="001">981878
+              </controlfield><datafield tag="035" ind1=" " ind2=" ">
+              <subfield code="a">zwirner_f_1</subfield><subfield 
+              code="9">arXiv</subfield></datafield></record></collection>
+           """
+
+TESTREC2 = """<collection><record><controlfield tag="001">982445
+              </controlfield><datafield tag="035" ind1=" " ind2=" ">
+              <subfield code="9">ARXIV</subfield>
+              <subfield code="a">ARXIV-ZACHOS-C-1</subfield>
+              </datafield></record></collection>
+           """
+
+TESTREC3 = """<collection><record><controlfield tag="001">1017924
+              </controlfield></record></collection>
+           """
+
+TESTREC4 = """<collection><record><controlfield tag="001">982447
+              </controlfield><datafield tag="035" ind1=" " ind2=" ">
+              <subfield code="9">ARXIV</subfield>
+              <subfield code="a"></subfield>
+              </datafield></record></collection>
+           """
+
+ARXIV_BAI_TEST = {
+    TESTREC1: '<a href="http://arxiv.org/a/zwirner_f_1">zwirner_f_1</a>',
+    TESTREC2: '<a href="http://arxiv.org/a/ARXIV-ZACHOS-C-1">ARXIV-ZACHOS-C-1</a>',
+    TESTREC3: None,
+    TESTREC4: None,
+}
+
+class HepNames_arxiv_BAI_format_test(unittest.TestCase):
+    def test4BAI_link(self):
+        for key in ARXIV_BAI_TEST:
+            bfo = BibFormatObject(None, xml_record=key)
+            out = bfe_INSPIRE_Hepnames_Arxiv_BAI.format_element(bfo)
+            self.assertEqual(ARXIV_BAI_TEST[key], out)
+
+TEST_SUITE = make_test_suite(HepNames_arxiv_BAI_format_test)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)

--- a/bibformat/format_templates/Hepnames_HTML_detailed.bft
+++ b/bibformat/format_templates/Hepnames_HTML_detailed.bft
@@ -20,6 +20,7 @@
 <BFE_INSPIRE_HEPNAMES_EMAIL prefix="<strong>Email: </strong>" suffix="<br />" separator="<br />" />
 <BFE_INSPIRE_URL prefix="<strong>URL:</strong> " suffix="<br />" separator="<br /><strong>URL: </strong>" />
 <BFE_INSPIRE_HEPNAMES_GSCHOLAR prefix="<strong>Google Scholar: </strong>" suffix="<br />" />
+<BFE_INSPIRE_HEPNAMES_ARXIV_BAI prefix="<strong>arXiv Author Identifier: </strong>" suffix="<br />" />
 <BFE_INSPIRE_HEPNAMES_FIELD_INTEREST prefix="<strong>Field: </strong>" suffix="<br />" />
 <BFE_INSPIRE_EXP_LINK prefix="<strong>Experiment: </strong>" suffix="<br />"/>
 <BFE_INSPIRE_HEPNAMES_BAI prefix="<strong>Author Profile: </strong>" suffix="<br />"/>


### PR DESCRIPTION
- BFE providing link to arXiv using arXiv author IDs found in MARC
- modified Hepnames_HTML_detailed.bft to include arXiv BAI link
- some unit tests for this format element

Signed-off-by: Thorsten Schwander thorsten.schwander@gmail.com
