### PR TITLE
general: support for arXiv 5-digits IDs

### DIFF
--- a/websubmit/Bibtex.py
+++ b/websubmit/Bibtex.py
@@ -102,7 +102,7 @@ def process_references(references, output_format):
             index = 'texkey'
         elif re.search(r'.*\/\d{7}', ref):
             index = 'eprint'
-        elif re.search(r'\d{4}\.\d{4}', ref):
+        elif re.search(r'\d{4}\.\d{4,5}', ref):
             index = 'eprint'
         elif re.search(r'\w\.\w+\.\w', ref):
             index = 'j'


### PR DESCRIPTION
- Amends the several regular expressions spread around the code that
  deal with arXiv identifiers so that the upcoming 5-digits based
  identifiers are also supported.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
