### PR TITLE
BibTasklets: webcoll post process error free

### DIFF
--- a/bibtasklets/bst_webcoll_postprocess.py
+++ b/bibtasklets/bst_webcoll_postprocess.py
@@ -22,8 +22,7 @@
 
 import requests
 
-from invenio.bibtask import (write_message,
-                             task_update_status)
+from invenio.bibtask import write_message
 from invenio.redisutils import get_redis
 
 try:
@@ -45,10 +44,9 @@ def bst_webcoll_postprocess(recids=[]):
 
     if not CFG_WEBCOLL_POST_REQUEST_URL:
         write_message("CFG_WEBCOLL_POST_REQUEST_URL is not set.")
-        task_update_status('ERROR')
-        return 1
+        return
 
-    if recids or not recids == "[]":
+    if recids and len(recids) > 0 and not recids == "[]":
         write_message("Going to POST callback to {0}: {1} (total: {2})".format(
             CFG_WEBCOLL_POST_REQUEST_URL,
             recids[:10],
@@ -65,7 +63,6 @@ def bst_webcoll_postprocess(recids=[]):
         else:
             write_message("Post request failed!")
             write_message(response.text)
-            task_update_status('ERROR')
             cache.set("webcoll_pending_recids", recids)
         session.close()
     else:


### PR DESCRIPTION
* Fixes an issue where the webcoll post-process task could cause
  the webcoll task to be stopped in the BibSched with errors.

Reported-by: Samuele Kaplun <samuele.kaplun@cern.ch>
Reported-by: Thorsten Schwander <thorsten.schwander@gmail.com>
Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>