### PR TITLE
BibFormat Hepnames Detailed HTML updates

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_Hepnames_ADS_link.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hepnames_ADS_link.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""BibFormat element - return link to ADS author page from HepNames record
+"""
+
+
+def format_element(bfo):
+    """
+    create link to author page at ADS from HepNames author data
+    """
+
+    import re
+    from cgi import escape
+    re_last_first = re.compile(
+        '^(?P<last>[^,]+)\s*,\s*(?P<first_names>[^\,]*)(?P<extension>\,?.*)$')
+    re_initials = re.compile(r'(?P<initial>\w)([\w`\']+)?.?\s*', re.UNICODE)
+
+    ADSURL = 'http://adsabs.harvard.edu/cgi-bin/author_form?'
+    author = bfo.field('100__a')
+
+    lastname = ''
+    firstnames = ''
+    initial = ''
+
+    if author:
+        amatch = re_last_first.search(author)
+        if amatch:
+            lastname = amatch.group('last')
+            firstnames = amatch.group('first_names')
+    if firstnames:
+        initialmatch = re_initials.search(unicode(firstnames, 'utf8'))
+        firstnames = re.sub('\s+', '+', firstnames)
+        if initialmatch:
+            initial = initialmatch.group('initial')
+
+    link = ''
+    if lastname:
+        lastname = re.sub('\s+', '+', lastname)
+        link = "%sauthor=%s,+%s&fullauthor=%s,+%s" % \
+               (ADSURL, lastname, initial, lastname, firstnames)
+    else:
+        link = "%sauthor=%s" % (ADSURL, bfo.field('100__q'))
+
+    return escape(link)
+
+
+# pylint: disable=W0613
+def escape_values(bfo):
+    """
+    Called by BibFormat in order to check if output of this element
+    should be escaped.
+    """
+
+    return 0
+# pylint: enable=W0613

--- a/bibformat/format_elements/bfe_INSPIRE_Hepnames_Native_Name.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hepnames_Native_Name.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2013 CERN.
+## Copyright (C) 2013, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -29,7 +29,7 @@ def format_element(bfo, css_class=''):
     if native_name:
         native_name = '(' + native_name + ')'
         if css_class:
-            return '<span class="' + css_class + '"> ' + native_name + "</span>"
+            return '<span class="%s"> %s</span>' % (css_class, native_name,)
         else:
             return native_name
     return ''

--- a/bibformat/format_elements/bfe_INSPIRE_Hepnames_ORCID.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hepnames_ORCID.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2014 CERN.
+## Copyright (C) 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -27,13 +27,13 @@ def format_element(bfo):
     bai = bfo.fields('035__')
 
     for item in bai:
-        if item.has_key('9') and item['9'] == 'ORCID' and item.has_key('a'):
+        if '9' in item and item['9'] == 'ORCID' and 'a' in item:
             orcid = item['a']
             if "http" in orcid:
-                return "<a href=%s>%s</a>" % (orcid, orcid)
+                return '<a href="%s">%s</a>' % (orcid, orcid)
             else:
                 link = "http://orcid.org/" + orcid
-                return "<a href=%s>%s</a>" % (link, orcid)
+                return '<a href="%s">%s</a>' % (link, orcid)
 
 
 def escape_values(bfo):

--- a/bibformat/format_templates/Hepnames_HTML_detailed.bft
+++ b/bibformat/format_templates/Hepnames_HTML_detailed.bft
@@ -10,7 +10,7 @@
 <a href="/search?ln=en&amp;cc=HepNames&amp;ln=en&amp;cc=HepNames&amp;p=701%3A%22<BFE_FIELD tag="100__a" />%22">[Students]</a>
 <a href="http://arxiv.org/find/all/1/au:<BFE_INSPIRE_HEPNAMES_ARXIV />/0/1/0/all/0/1?per_page=100">[arXiv]</a>
 <!-- http://arxiv.org/find/all/1/au:Brooks_T/0/1/0/all/0/1?per_page=100 -->
-<a href="http://adsabs.harvard.edu/cgi-bin/author_form?author=<BFE_FIELD tag="100__q" />">[ADS]</a>
+<a href="<BFE_INSPIRE_HEPNAMES_ADS_LINK />">[ADS]</a>
 
 <br /><br />
 


### PR DESCRIPTION
Alberto/ADS points out that the links to ADS author page from the HepNames Detailed page are incorrect

This patch introduces a new format_element bfe_INSPIRE_Hepnames_ADS_link.py which generates the correct link to include in the format template instead of inserting field 100__q verbatim.

Also included a simple fix to the ORCID link which is missing quotes around the href value.
