### PR TITLE
BibFormat: fix escape HepNames ADS link

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_Hepnames_ADS_link.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hepnames_ADS_link.py
@@ -26,7 +26,6 @@ def format_element(bfo):
     """
 
     import re
-    from cgi import escape
     re_last_first = re.compile(
         '^(?P<last>[^,]+)\s*,\s*(?P<first_names>[^\,]*)(?P<extension>\,?.*)$')
     re_initials = re.compile(r'(?P<initial>\w)([\w`\']+)?.?\s*', re.UNICODE)
@@ -57,7 +56,7 @@ def format_element(bfo):
     else:
         link = "%sauthor=%s" % (ADSURL, bfo.field('100__q'))
 
-    return escape(link)
+    return link
 
 
 # pylint: disable=W0613

--- a/bibformat/format_templates/Hepnames_HTML_detailed.bft
+++ b/bibformat/format_templates/Hepnames_HTML_detailed.bft
@@ -10,7 +10,7 @@
 <a href="/search?ln=en&amp;cc=HepNames&amp;ln=en&amp;cc=HepNames&amp;p=701%3A%22<BFE_FIELD tag="100__a" />%22">[Students]</a>
 <a href="http://arxiv.org/find/all/1/au:<BFE_INSPIRE_HEPNAMES_ARXIV />/0/1/0/all/0/1?per_page=100">[arXiv]</a>
 <!-- http://arxiv.org/find/all/1/au:Brooks_T/0/1/0/all/0/1?per_page=100 -->
-<a href="<BFE_INSPIRE_HEPNAMES_ADS_LINK />">[ADS]</a>
+<a href="<BFE_INSPIRE_HEPNAMES_ADS_LINK escape="8" />">[ADS]</a>
 
 <br /><br />
 


### PR DESCRIPTION
use bibformat built-in escaping in the template instead of manual escaping in the element following Sam's recommendation on previously deployed code.
