### PR TITLE
BibTasklets: better default in cds-synchro

### DIFF
--- a/bibtasklets/bst_inspire_cds_synchro.py
+++ b/bibtasklets/bst_inspire_cds_synchro.py
@@ -359,7 +359,7 @@ def import_recid_list(input_stream=sys.stdin, batch_limit=500, automatic_upload=
     return output_files
 
 
-def bst_inspire_cds_synchro(unmatched_only=True,
+def bst_inspire_cds_synchro(unmatched_only=False,
                             skip_extraction=False,
                             batch_limit=500,
                             automatic_upload=False):


### PR DESCRIPTION
* Keep basing synchronization on the 035 field.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>