### PR TITLE
BibHarvest: correct records correctly

### DIFF
--- a/bibharvest/bibfilter_oaiarXiv2inspire.py
+++ b/bibharvest/bibfilter_oaiarXiv2inspire.py
@@ -414,8 +414,7 @@ def main():
                         fields_to_add.append(("246", [field]))
                 else:
                     corrected_fields = []
-                    if has_field_origin(new_field_list, "arXiv", "9") \
-                       and has_field_origin(existing_field_list, "arXiv", "9"):
+                    if has_field_origin(new_field_list, "arXiv", "9"):
                         for field in existing_field_list:
                             if not "arXiv" in field_get_subfield_values(field, "9"):
                                 corrected_fields.append(field)


### PR DESCRIPTION
* Makes the arXiv harvesting filter correct existing fields
  in the correct way, e.g. not overriding existing 520 fields if
  the arXiv abstract was not there from the beginning.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>