### PR TITLE
bibcheck: new rules for BibTex cleanup

### DIFF
--- a/bibcheck/plugins/mvtexkey_a2z.py
+++ b/bibcheck/plugins/mvtexkey_a2z.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2013 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""
+Move additional texkeys from $$a to $$z 
+"""
+def check_record(record):
+    """
+    Move additional texkeys from $$a to $$z 
+    """
+    from invenio.bibrecord import record_modify_subfield
+    message = ""
+    all_a_keys = list(record.iterfield("035__a", ("9", "SPIRESTeX"))) \
+               + list(record.iterfield("035__a", ("9", "INSPIRETeX")))
+    if len(all_a_keys)>1:
+        message = "Move additional TexKeys from a to z:"
+        for position, value in all_a_keys[:-1]:
+            message += " %s" % value
+            record_modify_subfield(record, "035", "z", value, 
+                position[2], field_position_local=position[1])
+            record.set_amended(message)

--- a/bibcheck/plugins/mvtexkey_z2a.py
+++ b/bibcheck/plugins/mvtexkey_z2a.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2013 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""
+Move texkeys from $$z to $$a if there is no $$a
+"""
+def check_record(record):
+    """
+    Move one texkey from $$z to $$a if there is no $$a
+    """
+    from invenio.bibrecord import record_modify_subfield
+    message = ""
+    all_a_keys = list(record.iterfield("035__a", ("9", "SPIRESTeX"))) \
+               + list(record.iterfield("035__a", ("9", "INSPIRETeX")))
+    all_z_keys = list(record.iterfield("035__z", ("9", "SPIRESTeX"))) \
+               + list(record.iterfield("035__z", ("9", "INSPIRETeX")))
+
+    if all_a_keys:
+        pass
+    elif all_z_keys:
+        position, value = all_z_keys[0]
+        message = "Move TexKey from z to a: %s" % value
+        record_modify_subfield(record, "035", "a", value,
+           position[2], field_position_local=position[1])
+        record.set_amended(message)

--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -24,3 +24,12 @@ filter_collection = HEP
 
 [check_earliest_date]
 check = earliest_date
+
+[cleanup_texkey]
+check = mvtexkey_z2a
+filter_collection = HEP
+
+[regular_texkey]
+check = mvtexkey_a2z
+filter_collection = HEP
+


### PR DESCRIPTION
* Adds rules to move texkeys from a to z and vice versa.

Needs new version of bibcheck.iterfield with filter

Signed-off-by: Kirsten Sachs <kirsten.sachs@desy.de>