### PR TITLE
BibTaskLets: fix typo in consyn harvest logging

### DIFF
--- a/bibformat/format_templates/reference_update.bft
+++ b/bibformat/format_templates/reference_update.bft
@@ -185,18 +185,18 @@ function openSrchWindow(winputid) {
 <form name="referenceinp" method="post" onSubmit="return changec();" action="http://www.slac.stanford.edu/cgi-bin/form-mail.pl">
 
 
-<input type=hidden value="1" id="fieldcnt" name="storecnt">
-<INPUT type=hidden value=spires@slac.stanford.edu   name=to id=tofield>
+<input type="hidden" value="1" id="fieldcnt" name="storecnt">
+<INPUT type="hidden" value="HEP_ref_user@inspirehep.net" name="to" id="tofield">
 <!--<input type="hidden" name="debug" value="1">-->
-<INPUT type=hidden value=spires@slac.stanford.edu   name=form_contact id=fcfield>
-<INPUT type=hidden value="CITATION updates form INSPIRE" name=subject>
-<INPUT type=hidden name=response_msg value="thank you for using this form, you should soon see a response email">
-<INPUT type=hidden name=email_msg_file value="/spires/hepnames/inspcite_msg.file">
-<input type="hidden" name="recid" id="recid" value= "<BFE_RECORD_ID />">
-<input type=hidden name=dateupd value='<BFE_FIELD prefix="- as of date-upd: " tag="961c">'>
-<input type=hidden name=targfield id=targfield value="">
-<input type=hidden name=targfieldtwo id=targfieldtwo value="">
-<input type=hidden name=targfldthree id=targfldthree value="">
+<INPUT type="hidden" value="help@inspirehep.net" name="form_contact" id="fcfield">
+<INPUT type="hidden" value="CITATION updates form INSPIRE" name="subject">
+<INPUT type="hidden" name="response_msg" value="thank you for using this form, you should soon see a response email">
+<INPUT type="hidden" name="email_msg_file" value="/spires/hepnames/inspcite_msg.file">
+<input type="hidden" name="recid" id="recid" value="<BFE_RECORD_ID />">
+<input type="hidden" name="dateupd" value='<BFE_FIELD prefix="- as of date-upd: " tag="961c">'>
+<input type="hidden" name="targfield" id="targfield" value="">
+<input type="hidden" name="targfieldtwo" id="targfieldtwo" value="">
+<input type="hidden" name="targfldthree" id="targfldthree" value="">
 
 <div id="detailedrecordshortreminder">
   <a class = "titlelink" href="<BFE_SERVER_INFO var="recurl">">

--- a/bibtasklets/bst_consyn_harvest.py
+++ b/bibtasklets/bst_consyn_harvest.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of INSPIRE.
-## Copyright (C) 2014 CERN.
+## Copyright (C) 2014, 2015 CERN.
 ##
 ## INSPIRE is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -346,7 +346,7 @@ def download_feed(feed_url, batch_size, delete_zip, new_sources,
                 new_sources.append(outFilename)
             except InvenioFileDownloadError as err:
                 _errors_detected.append(err)
-                write_message("URL could not be opened: %s" + fileUrl)
+                write_message("URL could not be opened: %s" % fileUrl)
                 write_message(str(err))
                 write_message(traceback.format_exc()[:-1])
                 task_update_status("CERROR")


### PR DESCRIPTION
simple fix for logging, which currently looks like

....  URL could not be opened: %shttps://.........

e.g.

2015-06-23 00:12:18 --> Downloading https://consyn.elsevier.com/batch/download?key=MTM2OTMtMDAwMDEtRlVMTC1YTUwuWklQOzEzNjkzO0FIb2x0a2FtcDs%3d to /afs/cern.ch/project/inspire/uploads/elsevier/consyn/13693-00001-FULL-XML.ZIP

2015-06-23 00:20:39 --> URL could not be opened: %shttps://consyn.elsevier.com/batch/download?key=MTM2OTMtMDAwMDEtRlVMTC1YTUwuWklQOzEzNjkzO0FIb2x0a2FtcDs%3d
2015-06-23 00:20:39 --> URL could not be opened: 
2015-06-23 00:20:39 --> Traceback (most recent call last):
  File "/opt/cds-invenio/lib/python/invenio/bibsched_tasklets/bst_consyn_harvest.py", line 346, in download_feed
    download_url(fileUrl, "zip", outFilename, 5, 60.0)
  File "/usr/lib64/python2.6/site-packages/invenio/filedownloadutils.py", line 115, in download_url
    timeout=timeout)
  File "/usr/lib64/python2.6/site-packages/invenio/filedownloadutils.py", line 215, in download_external_url
    raise InvenioFileDownloadError(msg, code=error_code)
