### PR TITLE
bibformat: hepnames update link update

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_Hepnames_update_button.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hepnames_update_button.py
@@ -28,7 +28,7 @@ def format_element(bfo, separator='; '):
     except:
         return ''
 
-    url = "/person/update?IRN=" + urllib.quote(hepnames_id)
+    url = "http://labs.inspirehep.net/author/update?recid=" + urllib.quote(hepnames_id)
     return '<a href="' + url + '">' + '<img src="/img/update.jpg" alt="Update"/></a>'
 
 def escape_values(bfo):

--- a/feedboxes/portalbox-009-HepNames-rt-100.html
+++ b/feedboxes/portalbox-009-HepNames-rt-100.html
@@ -4,7 +4,7 @@
    <td>
     <h3>HEPNames</h3>
      <ul>
-     <li><a href="http://slac.stanford.edu/spires/hepnames/additions.shtml">Additions</a></li>
+     <li><a href="https://labs.inspirehep.net/author/new">Additions</a></li>
       <li><a href="/info/hep/corrections">Corrections</a></li>
       <li><a href="mailto:authors@inspirehep.net">Email Us</a></li>
       <li><a href="/info/HepNames/tools/index">Tools</a></li>


### PR DESCRIPTION
* Updates HepNames update link to point to new forms in
  labs.inspirehep.net.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>