### PR TITLE
BibFormat: multiple bibtex improvements

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_Conference_cite_date.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Conference_cite_date.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""BibFormat element - Prints INSPIRE Conference Date or Date Range
+                       suitable for use in citations
+"""
+
+import re
+
+MONTH = {'01': 'January',
+         '02': 'February',
+         '03': 'March',
+         '04': 'April',
+         '05': 'May',
+         '06': 'June',
+         '07': 'July',
+         '08': 'August',
+         '09': 'September',
+         '10': 'October',
+         '11': 'November',
+         '12': 'December'}
+
+SHORTMONTH = {m[:3]: m for m in MONTH.values()}
+
+monre = re.compile(r'\b(%s)\b' % '|'.join(SHORTMONTH.keys()))
+
+
+def short2long(matchobj):
+    """
+    return the full name of a month for 3 characer abbreviation
+    matchobj is the regular expression macth object
+    """
+    return SHORTMONTH.get(matchobj.group(0))
+
+
+def format_element(bfo, separator='-'):
+    """
+    return string containing conference date formatted for citation
+    or empty string
+    """
+
+    date = bfo.field('111__d')
+    if date:
+        date = date.rstrip()
+        date = date.lstrip()
+
+        date = monre.sub(short2long, date)
+
+        # convert to "Month Day, Year" form
+        date = re.sub(r'^([0-9 -]+)\s+([a-zA-Z]+),?\s+([0-9]+)$',
+                      r'\2 \1, \3',
+                      date)
+        # convert range with common Year, e.g.
+        # '24 August, 27 September 2013'
+        # '24 August - 27 September 2013'
+        # => 'August 24-September 27, 2013'
+        date = re.sub((r'^([0-9]+)\s+([a-zA-Z]+)'
+                       r'\s*\W\s*'
+                       r'([0-9]+)\s+([a-zA-Z]+)'
+                       r',?\s+([0-9]+)$'),
+                      r'\2 \1-\4 \3, \5',
+                      date)
+
+        return date
+
+    # start and end date should be "YYYY-MM-DD"
+    fdate = bfo.field('111__x')
+    if fdate:
+        fdate = fdate.rstrip()
+        try:
+            fyear, fmonth, fday = fdate.split('-')
+        except ValueError:
+            date = fdate
+            fdate = None
+
+        # get enddate if there is a startdate
+        ldate = bfo.field('111__y')
+        if ldate:
+            ldate = ldate.rstrip()
+            try:
+                lyear, lmonth, lday = ldate.split('-')
+            except ValueError:
+                ldate = None
+
+    if fdate:
+        date = '%s %s, %s' % (MONTH.get(fmonth, ''),
+                              fday.lstrip('0'),
+                              fyear)
+        if ldate and (fday != lday or fmonth != lmonth):
+            start = '%s %s' % (MONTH.get(fmonth, ''),
+                               fday.lstrip('0'))
+            end = '%s, %s' % (lday.lstrip('0'), lyear)
+
+            if fmonth != lmonth:
+                end = '%s %s' % (MONTH.get(lmonth, ''), end)
+            if fyear != lyear:
+                start = ' %s, %s' % (start, fyear)
+
+            date = '%s%s%s' % (start, separator, end)
+
+    return date
+
+
+# pylint: disable=W0613
+def escape_values(bfo):
+    """
+    Called by BibFormat in order to check if output of this element
+    should be escaped.
+    """
+    return 0
+# pylint: enable=W0613

--- a/bibformat/format_elements/bfe_INSPIRE_Conferences_date.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Conferences_date.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -19,7 +19,6 @@
 """BibFormat element - Prints INSPIRE jobs contact name HEPNAMES search
 """
 
-from urllib import quote_plus
 
 def format_element(bfo, style="", separator=''):
     """
@@ -61,54 +60,54 @@ def format_element(bfo, style="", separator=''):
                 fyear = fdate[:4]
 
     if smonth == '01':
-        smonth = smonth.replace('01','Jan')
+        smonth = smonth.replace('01', 'Jan')
     elif smonth == '02':
-        smonth = smonth.replace('02','Feb')
+        smonth = smonth.replace('02', 'Feb')
     elif smonth == '03':
-        smonth = smonth.replace('03','Mar')
+        smonth = smonth.replace('03', 'Mar')
     elif smonth == '04':
-        smonth = smonth.replace('04','Apr')
+        smonth = smonth.replace('04', 'Apr')
     elif smonth == '05':
-        smonth = smonth.replace('05','May')
+        smonth = smonth.replace('05', 'May')
     elif smonth == '06':
-        smonth = smonth.replace('06','Jun')
+        smonth = smonth.replace('06', 'Jun')
     elif smonth == '07':
-        smonth = smonth.replace('07','Jul')
+        smonth = smonth.replace('07', 'Jul')
     elif smonth == '08':
-        smonth = smonth.replace('08','Aug')
+        smonth = smonth.replace('08', 'Aug')
     elif smonth == '09':
-        smonth = smonth.replace('09','Sep')
+        smonth = smonth.replace('09', 'Sep')
     elif smonth == '10':
-        smonth = smonth.replace('10','Oct')
+        smonth = smonth.replace('10', 'Oct')
     elif smonth == '11':
-        smonth = smonth.replace('11','Nov')
+        smonth = smonth.replace('11', 'Nov')
     elif smonth == '12':
-        smonth = smonth.replace('12','Dec')
+        smonth = smonth.replace('12', 'Dec')
 
     if fmonth == '01':
-        fmonth = fmonth.replace('01','Jan')
+        fmonth = fmonth.replace('01', 'Jan')
     elif fmonth == '02':
-        fmonth = fmonth.replace('02','Feb')
+        fmonth = fmonth.replace('02', 'Feb')
     elif fmonth == '03':
-        fmonth = fmonth.replace('03','Mar')
+        fmonth = fmonth.replace('03', 'Mar')
     elif fmonth == '04':
-        fmonth = fmonth.replace('04','Apr')
+        fmonth = fmonth.replace('04', 'Apr')
     elif fmonth == '05':
-        fmonth = fmonth.replace('05','May')
+        fmonth = fmonth.replace('05', 'May')
     elif fmonth == '06':
-        fmonth = fmonth.replace('06','Jun')
+        fmonth = fmonth.replace('06', 'Jun')
     elif fmonth == '07':
-        fmonth = fmonth.replace('07','Jul')
+        fmonth = fmonth.replace('07', 'Jul')
     elif fmonth == '08':
-        fmonth = fmonth.replace('08','Aug')
+        fmonth = fmonth.replace('08', 'Aug')
     elif fmonth == '09':
-        fmonth = fmonth.replace('09','Sep')
+        fmonth = fmonth.replace('09', 'Sep')
     elif fmonth == '10':
-        fmonth = fmonth.replace('10','Oct')
+        fmonth = fmonth.replace('10', 'Oct')
     elif fmonth == '11':
-        fmonth = fmonth.replace('11','Nov')
+        fmonth = fmonth.replace('11', 'Nov')
     elif fmonth == '12':
-        fmonth = fmonth.replace('12','Dec')
+        fmonth = fmonth.replace('12', 'Dec')
 
     if printaddress in fulladdress:
         if not printaddress.has_key('d'):
@@ -123,6 +122,7 @@ def format_element(bfo, style="", separator=''):
                 ##year doesnt match. dont test month
                 out.append(sday+' '+smonth+' '+syear+' - '+fday+' '+fmonth+' '+fyear)
     return separator.join(out)
+
 
 def escape_values(bfo):
     """

--- a/bibformat/format_elements/bfe_INSPIRE_authors.py
+++ b/bibformat/format_elements/bfe_INSPIRE_authors.py
@@ -3,7 +3,7 @@
 ## $Id$
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2011 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -18,47 +18,59 @@
 ## You should have received a copy of the GNU General Public License
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
-"""BibFormat element - Prints authors
 """
-__revision__ = "$Id$"
+BibFormat element - Prints authors
 
-def format_element(bfo, limit, separator='; ',
-           extension='[...]',
-           print_links="yes",
-           print_affiliations='no',
-           affiliation_prefix=' (',
-           affiliation_suffix=')',
-           print_affiliation_first='no',
-           interactive="no",
-           highlight="no",
-           affiliations_separator=" ; ",
-           name_last_first="yes",
-           collaboration="yes",
-           id_links="no",
-           markup="html",
-           link_extension="no",
-           suffix=''
-           ):
+"""
+
+
+def format_element(
+        bfo, limit, separator='; ',
+        extension='[...]',
+        print_links="yes",
+        print_affiliations='no',
+        affiliation_prefix=' (',
+        affiliation_suffix=')',
+        print_affiliation_first='no',
+        interactive="no",
+        highlight="no",
+        affiliations_separator=" ; ",
+        name_last_first="yes",
+        collaboration="yes",
+        id_links="no",
+        markup="html",
+        link_extension="no",
+):
+
     """
     Prints the list of authors of a record.
 
     @param limit the maximum number of authors to display
     @param separator the separator between authors.
     @param extension a text printed if more authors than 'limit' exist
-    @param print_links if yes, prints the authors as HTML link to their publications
-    @param print_affiliations if yes, make each author name followed by its affiliation
+    @param print_links if yes, prints the authors as HTML link to their
+           publications
+    @param print_affiliations if yes, make each author name followed by
+           its affiliation
     @param affiliation_prefix prefix printed before each affiliation
     @param affiliation_suffix suffix printed after each affiliation
-    @param print_affiliation_first if 'yes', affiliation is printed before the author
-    @param interactive if yes, enable user to show/hide authors when there are too many (html + javascript)
-    @param highlight highlights authors corresponding to search query if set to 'yes'
+    @param print_affiliation_first if 'yes', affiliation is printed before
+           the author
+    @param interactive if yes, enable user to show/hide authors when there
+           are too many (html + javascript)
+    @param highlight highlights authors corresponding to search query if set
+           to 'yes'
     @param affiliations_separator separates affiliation groups
-    @param name_last_first if yes (default) print last, first  otherwise first last
-    @param collaboration if yes (default) uses collaboration name in place of long author list, if available
-    @param id_links if yes (default = no) prints link based on INSPIRE IDs if available - only used if print_links = yes
-    @param markup html (default) or latex controls small markup differences
+    @param name_last_first if yes (default) print last, first  otherwise
+           print first last
+    @param collaboration if yes (default) uses collaboration name in place
+           of long author list, if available
+    @param id_links if yes (default = no) prints link based on INSPIRE IDs
+           if available - only used if print_links = yes
+    @param markup html (default) or latex or bibtex controls small markup
+           differences
     @param link_extension if 'yes' link the extension to the detailed
-    record page
+           record page
 
     """
     from urllib import quote
@@ -75,10 +87,12 @@ def format_element(bfo, limit, separator='; ',
 
     _ = gettext_set_language(bfo.lang)    # load the right message language
 
-    #regex for parsing last and first names and initials
-    re_last_first = re.compile('^(?P<last>[^,]+)\s*,\s*(?P<first_names>[^\,]*)(?P<extension>\,?.*)$')
+    # regex for parsing last and first names and initials
+    re_last_first = re.compile(
+        r'^(?P<last>[^,]+)\s*,\s*(?P<first_names>[^\,]*)(?P<extension>\,?.*)$')
     re_initials = re.compile(r'(?P<initial>\w)([\w`\']+)?.?\s*', re.UNICODE)
-    re_tildehyph = re.compile(ur'(?<=\.)~(?P<hyphen>[\u002D\u00AD\u2010-\u2014-])(?=\w)', re.UNICODE)
+    re_tildehyph = re.compile(
+        ur'(?<=\.)~(?P<hyphen>[\u002D\u00AD\u2010-\u2014-])(?=\w)', re.UNICODE)
     re_coll = re.compile(r'\s*collaborations?', re.IGNORECASE)
 
     bibrec_id = bfo.control_field("001")
@@ -88,7 +102,7 @@ def format_element(bfo, limit, separator='; ',
     authors = bfo.fields('100__', repeatable_subfields_p=True)
     authors.extend(bfo.fields('700__', repeatable_subfields_p=True))
 
-    # If there are no author check for corporate author in 110__a field
+    # If there are no authors check for corporate author in 110__a field
     if len(authors) == 0:
         authors = bfo.fields('110__', repeatable_subfields_p=True)
         if len(authors) > 0:
@@ -98,105 +112,134 @@ def format_element(bfo, limit, separator='; ',
         # And we don't want to create links
         print_links = 'no'
 
-    # Keep real num of authors. fix + affiliations_separator.join(author['u']) + \
-    nb_authors = len(authors)
+    # authors is a list of dictionaries, count only those with names
+    # e.g. naive count of this
+    # [{'a': ['Toge, Nobu']},
+    #  {'u': ['Kek, High Energy Accelerator Research Organization']},
+    #  {'u': ['1-1 Oho, Tsukuba-Shi, Ibaraki-Ken, 305 Japan']}]
+    # would be 3, but there is only 1 author
+    nb_authors = len([au for au in authors if 'a' in au])
+
+    if markup == 'bibtex':
+        # skip editors
+        authors = [au for au in authors if 'a' in au
+                   and not ('e' in au and 'ed.' in au['e'])]
+        nb_authors = len(authors)
 
     # Limit num of authors, so that we do not process
     # the authors that will not be shown. This can only
     # be done in non-interactive mode, as interactive mode
     # allows to show all of them.
     if limit.isdigit() and nb_authors > int(limit) \
-           and interactive != "yes":
-        if bfo.field('710g'):   # check for colln note
-            authors = authors[:1]
-        else:
-
-            authors = authors[:int(limit)]
+            and interactive != "yes":
+        authors = authors[:1]
 
     # Process authors to add link, affiliation and highlight
     for author in authors:
-
-        if author.has_key('a'):
-            author['a'] = author['a'][0]  # There should not be
-                                          # repeatable subfields here.
+        if 'a' in author:
+            # There should not be repeatable subfields here
+            author['a'] = author['a'][0]
             if highlight == 'yes':
                 from invenio import bibformat_utils
                 author['a'] = bibformat_utils.highlight(author['a'],
                                                         bfo.search_pattern)
 
-            #check if we need to reverse last, first
-            #we don't try to reverse it if it isn't stored with a comma.
+            # check if we need to reverse last, first
+            # we don't try to reverse it if it isn't stored with a comma.
             first_last_match = re_last_first.search(author['a'])
             author['display'] = author['a']
 
             if name_last_first.lower() == "no":
                 if first_last_match:
-                    author['display'] = first_last_match.group('first_names') + \
-                                        ' ' + \
-                                        first_last_match.group('last') + \
-                                        first_last_match.group('extension')
+                    author['display'] = "%s %s%s" % (
+                        first_last_match.group('first_names'),
+                        first_last_match.group('last'),
+                        first_last_match.group('extension'),)
 
-            #for latex we do initials only  (asn assume first last)
+            # for latex we do initials only (and assume first last)
             if markup == 'latex':
                 if first_last_match:
-                    first = re_initials.sub('\g<initial>.~', \
-                                            unicode(first_last_match.group('first_names'), 'utf8'))
-                    first = re_tildehyph.sub('\g<hyphen>', first)
-                    author['display'] = first  + \
-                                        first_last_match.group('last') + \
-                                        first_last_match.group('extension')
+                    first = re_initials.sub(
+                        r'\g<initial>.~',
+                        unicode(first_last_match.group('first_names'), 'utf8'))
+                    first = re_tildehyph.sub(r'\g<hyphen>', first)
+                    author['display'] = first + \
+                        first_last_match.group('last') + \
+                        first_last_match.group('extension')
 
+            # custom name handling for bibtex
+            if markup == 'bibtex':
+                if first_last_match:
+                    junior = first_last_match.group('extension')
+                    if re.search(r'\b([JS]r\.)?$', junior) or \
+                            re.search('([IV]{2,})$', junior):
+                        author['display'] = "%s%s, %s" % (
+                            first_last_match.group('last'),
+                            junior,
+                            first_last_match.group('first_names'),)
+                    else:
+                        author['display'] = "%s, %s%s" % (
+                            first_last_match.group('last'),
+                            first_last_match.group('first_names'),
+                            junior,)
+
+                    # avoid trailing comma for single name author
+                    author['display'] = author['display'].rstrip(', ')
+
+                    # multi-letter initial (in particular Russian Yu.)
+                    author['display'] = re.sub(
+                        r'\bYu\.',
+                        r'{\\relax Yu}.', author['display'])
 
             if print_links.lower() == "yes":
-
                 # if there is an ID, search using that.
                 id_link = ''
-                if id_links == "yes" and author.has_key('i'):
-                    author['i'] = author['i'][0]  #possible to have more IDs?
+                if id_links == "yes" and 'i' in author:
+                    author['i'] = author['i'][0]  # possible to have more IDs?
                     id_link = '<a class="authoridlink" href="' + \
                               CFG_BASE_URL + \
-                              '/search?' + \
-                              'ln='+ bfo.lang + \
-                              '&amp;p=100__i' + escape(':' + author['i']) + \
-                              '+or+700__i' + escape(':' + author['i']) +\
-                              '">'+escape("(ID Search)") + '</a> '
-
+                              '/search?ln=' + bfo.lang + \
+                              '&amp;p=100__i:' + escape(author['i']) + \
+                              '+or+700__i:' + escape(author['i']) +\
+                              '">' + escape("(ID Search)") + '</a> '
 
                 author['display'] = '<a class="authorlink" href="' + \
                                     CFG_BASE_URL + \
-                                    '/author/profile/'+ quote(author['a']) + \
+                                    '/author/profile/' + quote(author['a']) + \
                                     '?recid=' + bibrec_id + \
-                                    '&amp;ln='+ bfo.lang + \
+                                    '&amp;ln=' + bfo.lang + \
                                     '">' + escape(author['display'])+'</a>' + \
                                     id_link
 
         if print_affiliations == "yes":
-            if author.has_key('e'):
+            if 'e' in author:
                 author['e'] = affiliation_prefix + \
-                              affiliations_separator.join(author['e']) + \
-                              affiliation_suffix
+                    affiliations_separator.join(author['e']) + \
+                    affiliation_suffix
 
-
-
-            if author.has_key('u'):
-                author['ilink'] = ['<a class="afflink" href="' + \
-                                   CFG_BASE_URL + '/search?cc=Institutions&amp;p=institution:'+ \
-                                   quote('"' + string + '"') + \
-                                   '&amp;ln=' + bfo.lang + \
-                                   '">' + \
-                                   string.lstrip() + \
-                                   '</a>' for string in author['u']]
+            if 'u' in author:
+                author['ilink'] = [
+                    '<a class="afflink" href="' +
+                    CFG_BASE_URL +
+                    '/search?cc=Institutions&amp;p=institution:' +
+                    quote('"' + string + '"') +
+                    '&amp;ln=' + bfo.lang +
+                    '">' +
+                    string.lstrip() +
+                    '</a>' for string in author['u']
+                ]
                 author['u'] = affiliation_prefix + \
-                              affiliations_separator.join(author['ilink']) + \
-                              affiliation_suffix
+                    affiliations_separator.join(author['ilink']) + \
+                    affiliation_suffix
 
 #
 #  Consolidate repeated affiliations
 #
+
     last = ''
     authors.reverse()
     for author in authors:
-        if not author.has_key('u'):
+        if 'u' not in author:
             author['u'] = ''
         #print 'this->'+ author['a']+'\n'
         if last == author['u']:
@@ -208,24 +251,22 @@ def format_element(bfo, limit, separator='; ',
 
     # Flatten author instances
     if print_affiliations == 'yes':
-##      100__a (100__e)  700__a (100__e) (100__u)
+        # 100__a (100__e)  700__a (100__e) (100__u)
         if print_affiliation_first.lower() != 'yes':
-            authors = [author.get('display', '') + author.get('e', '') + author.get('u', '')
-                       for author in authors]
-
+            authors = [author.get('display', '') + author.get('e', '') +
+                       author.get('u', '') for author in authors]
         else:
             authors = [author.get('u', '') + author.get('display', '')
                        for author in authors]
-
     else:
         authors = [author.get('display', '')
-                   for author in authors]
+                   for author in authors if 'display' in author]
 
     # link the extension to detailed record
     if link_extension == 'yes' and interactive != 'yes':
         extension = '<a class="authorlink" href="' +  \
-                    CFG_BASE_URL + '/' + CFG_SITE_RECORD + '/' + str(bfo.recID) + '">' + \
-                    extension + '</a>'
+            CFG_BASE_URL + '/' + CFG_SITE_RECORD + '/' + str(bfo.recID) \
+            + '">' + extension + '</a>'
 
     # Detect Collaborations:
     if collaboration == "yes":
@@ -235,6 +276,7 @@ def format_element(bfo, limit, separator='; ',
                 colls.append(coll)
     else:
         colls = []
+
     if colls:
         short_coll = False
         colls = [re_coll.sub('', coll) for coll in colls]
@@ -251,24 +293,25 @@ def format_element(bfo, limit, separator='; ',
             if len(colls) > 1:
                 coll_display += 's'
         if nb_authors > 1:
-            if markup == 'latex':
-                coll_display = authors[0] + extension + "  [" + \
-                               coll_display + "]"
+            if markup in ('latex', 'bibtex'):
+                coll_display = authors[0] + extension + " [" + \
+                    coll_display + "]"
             elif interactive == "yes":
-                coll_display += " ("  + authors[0] + " "
+                coll_display += " (" + authors[0] + " "
                 extension += ")"
-            else:  #html
+            else:  # html
                 coll_display += " (" + authors[0] + extension + ")"
         elif nb_authors == 1:
             short_coll = True
-            if markup == 'latex':
+            if markup in ('latex', 'bibtex'):
                 coll_display = authors[0] + " [" + coll_display + "]"
-            else:  #html
+            else:  # html
                 if not only_corporate_author:
-                    coll_display += " (" + authors[0] + " for the collaboration)"
+                    coll_display += " (" + authors[0] + \
+                                    " for the collaboration)"
         elif nb_authors == 0:
             short_coll = True
-            if markup == 'latex':
+            if markup in ('latex', 'bibtex'):
                 coll_display = "[" + coll_display + "]"
 
     # Start outputting, depending on options and number of authors
@@ -276,15 +319,12 @@ def format_element(bfo, limit, separator='; ',
         return coll_display
 
     if limit.isdigit() and nb_authors > int(limit) and interactive != "yes":
-        if markup == 'latex':
-            lastauthor = authors.pop()
-            lastauthor = ' and ' + lastauthor
-            limit = int(limit) - 1
-
         return separator.join(authors[:int(limit)]) + lastauthor + \
-               extension
+            extension
 
-    elif interactive == "yes" and ((colls and not short_coll) or (limit.isdigit() and nb_authors > int(limit))):
+    elif interactive == "yes" and \
+            ((colls and not short_coll) or
+             (limit.isdigit() and nb_authors > int(limit))):
         out = '''
         <script>
         function toggle_authors_visibility(){
@@ -331,15 +371,10 @@ def format_element(bfo, limit, separator='; ',
         out += '<script>set_up()</script>'
         return out
     elif nb_authors > 0:
-        if markup == 'latex' and nb_authors > 1:
-            lastauthor = authors.pop()
-            lastauthor = ' and ' + lastauthor
-        output = separator.join(authors) + lastauthor
-        # remove the dot from the end of authors list when the suffix starts with dot
-        # (to avoid two consecutive dots)
-        if suffix and output and output[-1] == suffix[0] == '.':
-            output = output[:-1]
-        return output
+        if markup in ('latex', 'bibtex'):
+            if nb_authors > 1:
+                lastauthor = ' and ' + authors.pop()
+        return separator.join(authors) + lastauthor
 
 # we know the argument is unused, thanks
 # pylint: disable=W0613

--- a/bibformat/format_elements/bfe_INSPIRE_bibtex.py
+++ b/bibformat/format_elements/bfe_INSPIRE_bibtex.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2011 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -16,15 +16,21 @@
 ## You should have received a copy of the GNU General Public License
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
-"""BibFormat element - Prints BibTeX meta-data"""
+"""
+BibFormat element - Prints BibTeX meta-data
+
+"""
 
 
+import cgi
 import re
-from invenio.config import CFG_SITE_LANG
+
 from invenio.bibformat_elements import bfe_report_numbers as bfe_repno
+from invenio.config import CFG_SITE_LANG
+from invenio.search_engine import get_fieldvalues, search_pattern
 
 
-def format_element(bfo, width="50"):
+def format_element(bfo, width="50", show_abstract=False):
     """
     Prints a full BibTeX record.
 
@@ -50,228 +56,382 @@ def format_element(bfo, width="50"):
 
     # Initialize user output
     out = "@"
+    erratum_note = ''
+    displaycnt = 0
 
     def texified(name, value):
-        """Closure of format_bibtex_field so we don't keep pasing static data
-    
+        """Closure of format_bibtex_field so we don't keep passing static data
+
         Saves a little bit of boilerplate.
         """
         return format_bibtex_field(name, value, name_width, value_width)
 
-    #Print entry type
-    import invenio.bibformat_elements.bfe_collection as bfe_collection
-    collection = bfe_collection.format_element(bfo=bfo, kb="DBCOLLID2BIBTEX")
-    if collection == "":
-        out += "article"
-        collection = "article"
-    else:
-        out += collection
+    # map INSPIRE collection types to bibtex entry_type labels
 
-    out += "{"
+    entry_type = 'article'
+
+    collections = [c.lower() for c in bfo.fields("980__a")]
+    if "conferencepaper" in collections:
+        entry_type = 'inproceedings'
+    elif 'thesis' in collections:
+        # Master thesis has to be identified
+        if bfo.field("502__b") == 'Master':
+            entry_type = 'mastersthesis'
+        else:
+            entry_type = 'phdthesis'
+    elif 'proceedings' in collections:
+        entry_type = 'proceedings'
+    elif 'book' in collections:
+        entry_type = 'book'
+    elif 'bookchapter' in collections:
+        entry_type = 'incollection'
+    elif 'arxiv' in collections:
+        entry_type = 'article'
+
+    # Irrespective of type, check for complete journal info -> @article
+    origentry = entry_type
+    for j in bfo.fields("773__"):
+        if j.get('p', '') and j.get('v', '') \
+           and j.get('c', '') and j.get('y', ''):
+                entry_type = 'article'
+
+    out += entry_type + "{"
 
     # BibTeX key
     import invenio.bibformat_elements.bfe_texkey as bfe_texkey
     key = bfe_texkey.format_element(bfo, harvmac=False)
-
-#    key = ''
-#    for external_keys in bfo.fields("035"):
-#        if external_keys['9'] == "SPIRESTeX" and external_keys['z']:
-#            key = external_keys['z']
-#    if not key:
-#        #contruct key in spires like way  need to store an make unique
-#        ####FIXME
-#        key = bfo.field("100a").split(' ')[0].lower() + ":" + \
-#              bfo.field("269c").split('-')[0] + \
-#              chr((recID % 26) + 97) + chr(((recID / 26) % 26) + 97)
     out += key + ','
 
-        #If author cannot be found, print a field key=recID
+    # KEY
+    # if no texkey is found, print a key element with recID
+    if not key:
+        out += texified("key", recID)
+
+    # Authors
     import invenio.bibformat_elements.bfe_INSPIRE_authors as bfe_authors
     authors = bfe_authors.format_element(bfo=bfo,
-                                 limit="5",
-                                 separator=" and ",
-                                 extension=" and others",
-                                 collaboration = "no",
-                                 print_links="no",
-                                 name_last_first = "yes")
-    if authors:
-
-        rx = re.compile('([A-Za-z\,\'\-\s]+?\.)([A-Z][a-z]+)')
-        auspace = rx.sub(r'\1 \2', authors, count=0)
-        out += texified("author", auspace)
-
-    else:
-        out += texified("key", recID)
+                                         limit="10",
+                                         separator=" and ",
+                                         extension=" and others",
+                                         collaboration="no",
+                                         print_links="no",
+                                         name_last_first="yes",
+                                         markup="bibtex")
 
     # Editors
     import invenio.bibformat_elements.bfe_editors as bfe_editors
     editors = bfe_editors.format_element(bfo=bfo, limit="10",
-                                 separator=" and ",
-                                 extension="",
-                                 print_links="no")
-    out += texified("editor", editors)
+                                         separator=" and ",
+                                         extension=" and others ",
+                                         print_links="no")
+
+    spacinginitials = re.compile(r'([A-Z][a-z]{0,1}[}]?\.)(\b|[-\{])')
+    if authors:
+        # bibtex requires spaces after initials in names (authors/editors)
+        # FIXME: use posix [[:upper:]][[:lower:]]{0,1} and re.UNICODE
+        # FIXME: do we want A.-B. => A. -B. ?
+        authors = spacinginitials.sub(r'\1 \2', authors)
+        out += texified("author", authors)
+
+    if editors:
+        editors = spacinginitials.sub(r'\1 \2', editors)
+        if entry_type == 'article' and not authors:
+            # satisfy @article required fields
+            out += texified("author", editors)
+        else:
+            out += texified("editor", editors)
 
     # Title
     import invenio.bibformat_elements.bfe_INSPIRE_title_brief as bfe_title
     title = bfe_title.format_element(bfo=bfo, brief="yes")
-    out += texified("title", '{' + title + '}')
+    if title:
+        # don't escape "$", assume it's a math delimiter
+        title = re.sub(r'(?<!\\)([#_&%])', r'\\\1', title)
+        title = '{' + title + '}'
+        out += texified("title", title)
+
+    # BookTitle
+    # ConferencePaper retrieve parent proceeding's title information
+    booktitle = ''
+    if entry_type == 'inproceedings' or origentry == 'inproceedings':
+        import bfe_INSPIRE_inproc_booktitle
+        booktitle = bfe_INSPIRE_inproc_booktitle.format_element(bfo)
+
+        if booktitle:
+            # $ in booktitle is often a monetary dollar
+            bt = re.sub(r'(?<!\\)([#_&%$])', r'\\\1', booktitle)
+            out += texified("booktitle", '{' + bt + '}')
+    # bookchapter, retrieve book's title and editor info
+    if entry_type in ('incollection'):
+        # 1) recid:[773__0]  (245 $$a: $$b + editors)
+        bookid = bfo.field("773__0")
+        # 2) reportnumber:[773__r]  (245 $$a: $$b + editors)
+        if not bookid:
+            rn = bfo.field("773__r")
+            if rn:
+                bookid = search_pattern(p='reportnumber:' + rn)[0]
+        # 3) isbn:[773__z]  (245 $$a: $$b + editors)
+        if not bookid:
+            isbn = bfo.field("773__z")
+            if isbn:
+                bookid = search_pattern(p='isbn:' + rn)[0]
+        if bookid:
+            if not isinstance(bookid, int):
+                bookid = int(bookid)
+            maintitle = get_fieldvalues(bookid, '245__a')
+            if maintitle:
+                booktitle = maintitle[0]
+                subtitle = get_fieldvalues(bookid, '245__b')
+                if subtitle:
+                    booktitle += ': ' + subtitle[0]
+            # editors
+            from invenio.bibformat_engine import BibFormatObject
+            bfb = BibFormatObject(bookid)
+            editors = bfe_editors.format_element(bfo=bfb,
+                                                 limit="10",
+                                                 separator=" and ",
+                                                 extension=" and others ",
+                                                 print_links="no")
+            if editors:
+                out += texified('editor', editors)
+        # 4) [773__x]
+        if not booktitle:
+            booktitle = bfo.field("773__x")
+        if booktitle:
+            out += texified("booktitle", booktitle)
 
     # Institution
-    if collection ==  "techreport":
+    if entry_type == "techreport":
         publication_name = bfo.field("269__b")
         out += texified("institution", publication_name)
 
     # Organization
-    if collection == "inproceedings" or collection == "proceedings":
+    if entry_type in ['inproceedings', 'proceedings']:
         organization = []
         organization_1 = bfo.field("260__b")
-        if organization_1 != "":
+        if organization_1:
             organization.append(organization_1)
         organization_2 = bfo.field("269__b")
-        if organization_2 != "":
+        if organization_2:
             organization.append(organization_2)
         out += texified("organization", ". ".join(organization))
 
     # Publisher
-    if collection == "book" or \
-           collection == "inproceedings" \
-           or collection == "proceedings":
+    if entry_type in ['incollection', 'book', 'inproceedings', 'proceedings']:
         publishers = []
         import invenio.bibformat_elements.bfe_publisher as bfe_publisher
         publisher = bfe_publisher.format_element(bfo=bfo)
-        if publisher != "":
+        if publisher:
             publishers.append(publisher)
         publication_name = bfo.field("269__b")
-        if publication_name != "":
+        if publication_name:
             publishers.append(publication_name)
         imprint_publisher_name = bfo.field("933__b")
-        if imprint_publisher_name != "":
+        if imprint_publisher_name:
             publishers.append(imprint_publisher_name)
         imprint_e_journal__publisher_name = bfo.field("934__b")
-        if imprint_e_journal__publisher_name != "":
+        if imprint_e_journal__publisher_name:
             publishers.append(imprint_e_journal__publisher_name)
 
         out += texified("publisher", ". ".join(publishers))
 
     # Collaboration
-    collaborations = []
-    for collaboration in bfo.fields("710__g"):
-        if collaboration not in collaborations:
-            collaborations.append(collaboration)
-    out += texified("collaboration", ", ".join(collaborations))
+    out += texified("collaboration", ", ".join(
+        set(re.sub(r'(.+)?\s+[Cc]ollaboration', r'\1', c)
+            for c in bfo.fields("710__g")))
+    )
 
+    yearset = False
     # School
-    if collection == "phdthesis":
-        university = bfo.field("502__b")
+    if entry_type in ['phdthesis', 'mastersthesis']:
+        university = bfo.field("100__u")
 
         out += texified("school", university)
 
+        thesisyear = bfo.field("502__d")
+        if thesisyear:
+            yearset = True
+            out += texified("year", thesisyear)
+
     # Address
-    if collection == "book" or \
-           collection == "inproceedings" or \
-           collection == "proceedings" or \
-           collection == "phdthesis" or \
-           collection == "techreport":
+    if entry_type in ['incollection', 'book', 'inproceedings', 'proceedings',
+                      'phdthesis', 'mastersthesis', 'techreport']:
         addresses = []
         publication_place = bfo.field("260__a")
-        if publication_place != "":
+        if publication_place:
             addresses.append(publication_place)
         publication_place_2 = bfo.field("269__a")
-        if publication_place_2 != "":
+        if publication_place_2:
             addresses.append(publication_place_2)
         imprint_publisher_place = bfo.field("933__a")
-        if imprint_publisher_place != "":
+        if imprint_publisher_place:
             addresses.append(imprint_publisher_place)
         imprint_e_journal__publisher_place = bfo.field("934__a")
-        if imprint_e_journal__publisher_place != "":
+        if imprint_e_journal__publisher_place:
             addresses.append(imprint_e_journal__publisher_place)
 
         out += texified("address", ". ".join(addresses))
 
-    # Journal
-    if collection == "article":
-        journals = []
-        host_title = bfo.field("773__p")
-        if host_title != "":
-            journals.append(host_title)
-        journal = bfo.field("909C4p")
-        if journal != "":
-            journals.append(journal)
+        # Pubyear
+        if not yearset:
+            pubyear = get_year(bfo.field("260__c"))
+            if pubyear:
+                yearset = True
+                out += texified("year", pubyear)
 
-        out += texified("journal", ". ".join(journals))
+        # URL
+        urls = bfo.fields("8564_u")
+        # FIXME: use bibdocfile doctype not PLOT or INSPIRE-PUBLIC
+        for url in urls:
+            if url.lower().endswith(
+                    ('.png', '.jpg', '.jpeg', '.gif', '.eps')):
+                continue
+            else:
+                out += texified("url", url)
+                break
+
+    # Journal
+    pagesset = False
+    if entry_type in ['article', 'inproceedings']:
+        journal_infos = bfo.fields("773__")
+        for journal_info in journal_infos:
+            journal_source = cgi.escape(journal_info.get('p', ''))
+            volume = cgi.escape(journal_info.get('v', ''))
+            number = cgi.escape(journal_info.get('n', ''))
+            pages = cgi.escape(journal_info.get('c', ''))
+            erratum = cgi.escape(journal_info.get('m', ''))
+
+            year = cgi.escape(journal_info.get('y', ''))
+            if not year:
+                year = get_year(bfo.field("269__c"))
+                if not year:
+                    year = get_year(bfo.field("260__c"))
+                    if not year:
+                        year = get_year(bfo.field("502__d"))
+
+            str773 = ''
+            if journal_source:
+                jsub = re.sub(r'\.([A-Z])', r'. \1', journal_source)
+                if not (volume or number or pages
+                        or bfo.field("0247_2") == 'DOI'):
+                    str773 += 'Submitted to: ' + jsub
+                else:
+                    str773 += jsub
+                if displaycnt == 0:
+                    out += texified("journal", str773)
+            if volume:
+                if str773.find("JHEP") > -1:
+                    volume = re.sub(r'\d\d(\d\d)', r'\1', volume)
+                if displaycnt == 0:
+                    out += texified("volume", volume)
+                else:
+                    str773 += volume
+            if year:
+                if displaycnt == 0 and not yearset:
+                    yearset = True
+                    out += texified("year", year)
+                else:
+                    year = '(' + year + ')'
+            if number:
+                if displaycnt == 0:
+                    out += texified("number", number)
+                else:
+                    str773 += ',no.' + number
+            if pages:
+                if displaycnt == 0:
+                    pagesset = True
+                    out += texified("pages", pages)
+                else:
+                    str773 += ',' + pages.split('-', 1)[0]
+
+            if str773:
+                str773 += year
+
+    # N.B. In cases where there is more than one journal in journals iteration
+    # the second pass is usually a cite for a translation or something else to
+    # appear in a note. Therefore erratum_note is set to display this data
+    # later on.
+
+            displaycnt += 1
+            if displaycnt > 1 and str773:
+                if erratum.lower() in \
+                   ('erratum', 'addendum', 'corrigendum', 'reprint'):
+                    str773 = '[%s: %s]' % (erratum, str773,)
+                else:
+                    str773 = '[' + str773 + ']'
+                erratum_note = texified("note", str773)
+
+    # Publication/Journal Name for non-article types
+    if entry_type in ['book', 'incollection', 'proceedings']:
+        pname = bfo.field("773__p")
+        if pname:
+            jsub = re.sub(r'\.([A-Z])', r'. \1', pname)
+            out += texified("journal", jsub)
+        else:
+            xstring = bfo.field("773__x")
+            if xstring:
+                out += texified("journal", xstring)
 
     # Number
-    if collection == "techreport" or \
-           collection == "article":
-        numbers = []
-        host_number = bfo.field("773__n")
-        if host_number != "":
-            numbers.append(host_number)
-        number = bfo.field("909C4n")
-        if number != "":
-            numbers.append(number)
-        out += texified("number", ". ".join(numbers))
+    if entry_type in ['book', 'incollection', 'proceedings', 'techreport']:
+        number = bfo.field("773__n")
+        if number:
+            out += texified("number", number)
 
     # Volume
-    if collection == "article" or \
-           collection == "book":
+    if entry_type in ['book', 'incollection', 'proceedings']:
         volumes = []
         host_volume = bfo.field("773__v")
-        if host_volume != "":
+        if host_volume:
             volumes.append(host_volume)
-        volume = bfo.field("909C4v")
-        if volume != "":
+        volume = bfo.field("490__v")
+        if volume:
             volumes.append(volume)
 
         out += texified("volume", ". ".join(volumes))
 
     # Series
-    if collection == "book":
+    if entry_type in ['book', 'incollection', 'proceedings']:
         series = bfo.field("490__a")
         out += texified("series", series)
 
     # Pages
-    if collection == "article" or \
-           collection == "inproceedings":
-        pages = []
-        host_pages = bfo.field("773c")
-        if host_pages != "":
-            pages.append(host_pages)
-            nb_pages = bfo.field("909C4c")
-            if nb_pages != "":
-                pages.append(nb_pages)
-                phys_pagination = bfo.field("300__a")
-                if phys_pagination != "":
-                    pages.append(phys_pagination)
-
-        out += texified("pages", ". ".join(pages))
+    if entry_type in ['incollection', 'inproceedings', 'proceedings'] \
+       and not pagesset:
+        pages = bfo.field("773__c")
+        if pages:
+            pagesset = True
+            out += texified("pages", pages)
 
     # DOI
-    if collection == "article" or \
-            collection == "data":
-        if bfo.field("0247_2") == 'DOI':
-            dois = bfo.fields("0247_a") + bfo.fields("773__a")
-            out += texified("doi", ", ".join(set(dois)))
-        elif bfo.field("0247_2") == 'HDL':
-            handles = bfo.fields("0247_a") + bfo.fields("773__a")
-            out += texified("handle", ", ".join(set(handles)))
+    if bfo.field("0247_2") == 'DOI':
+        dois = bfo.fields("0247_a") + bfo.fields("773__a")
+        out += texified("doi", ", ".join(set(dois)))
+    elif bfo.field("0247_2") == 'HDL':
+        handles = bfo.fields("0247_a") + bfo.fields("773__a")
+        out += texified("handle", ", ".join(set(handles)))
 
     # Year
-    year = bfo.field("773__y")
-    if year == "":
-        year = get_year(bfo.field("269__c"))
-        if year == "":
-            year = get_year(bfo.field("260__c"))
-            if year == "":
-                year = get_year(bfo.field("502__c"))
-                if year == "":
-                    year = get_year(bfo.field("909C0y"))
-    out += texified("year", year)
+    # if there was journal info, we already printed the year
+    if not yearset:
+        year = bfo.field("773__y")
+        if not year:
+            year = get_year(bfo.field("269__c"))
+            if not year:
+                year = get_year(bfo.field("260__c"))
+                if not year:
+                    year = get_year(bfo.field("502__d"))
+        if year:
+            yearset = True
+            out += texified("year", year)
+
+    # Erratum note stuff here
+    out += erratum_note
 
     # Eprint (aka arxiv number)
     import invenio.bibformat_elements.bfe_INSPIRE_arxiv as bfe_arxiv
-    eprints = bfe_arxiv.get_arxiv(bfo, category = "no")
-    cats    = bfe_arxiv.get_cats(bfo)
+    eprints = bfe_arxiv.get_arxiv(bfo, category="no")
+    cats = bfe_arxiv.get_cats(bfo)
     if eprints:
         eprint = eprints[0]
         if eprint.upper().startswith('ARXIV:'):
@@ -284,26 +444,67 @@ def format_element(bfo, width="50"):
     else:
         # No eprints, but we don't want refs to eprints[0] to error out below
         # This makes everything work nicely without a lot of extra gating
-        eprints=[None]
-
+        eprints = [None]
 
     # Other report numbers
-    out += texified("reportNumber", 
-                    bfe_repno.get_report_numbers_formatted(bfo, 
-                                                           separator=', ', 
-                                                           limit='1000', 
-                                                           skip=eprints[0]))
+    out += texified("reportNumber",
+                    bfe_repno.get_report_numbers_formatted(
+                        bfo,
+                        separator=', ',
+                        limit='1000',
+                        skip=eprints[0])
+                    )
+#    if entry_type == "inproceedings" and :
+#        pubnote = bfo.field("500__a")
+#        out += texified("note", pubnote)
+
+    # ISBN
+    if entry_type in ['book', 'proceeedings']:
+        isbn = bfo.fields("020__a")
+        # Inspire frequently has multiple ISBN for different types, e.g.
+        # 001242544 020__ $$a9781927763124$$bebook
+        # 001242544 020__ $$a9781927763117$$bsoftcover
+        # FIXME: normalize ISBN to hyphenated form, see
+        #        https://pypi.python.org/pypi/isbnlib/3.5.5
+
+        out += texified('ISBN', ', '.join(isbn))
 
     # Add %%CITATION line
     import invenio.bibformat_elements.bfe_INSPIRE_publi_info_latex as bfe_pil
     import invenio.bibformat_elements.bfe_INSPIRE_publi_coden as bfe_coden
-    cite_as = bfe_pil.get_cite_line(arxiv=eprints[0], 
-                                    pubnote=bfe_coden.get_coden_formatted(bfo, ','),
-                                    repno=bfe_repno.get_report_numbers_formatted(bfo, '', '1'),
-                                    bfo=bfo)
+    cite_as = bfe_pil.get_cite_line(
+        arxiv=eprints[0],
+        pubnote=bfe_coden.get_coden_formatted(bfo, ','),
+        repno=bfe_repno.get_report_numbers_formatted(
+            bfo, separator='', limit='1', extension=''),
+        bfo=bfo)
+
     out += texified("SLACcitation", cite_as)
 
-    out +="\n}"
+    # optionally display abstract
+    # FIXME: abstract requires escaping/quoting
+    if show_abstract == "True":
+        abstract = bfo.field("520__a")
+        if len(abstract) > 1000:
+            abstract = abstract[:1000] + '...'
+        out += texified("abstract", '{' + abstract + '}')
+
+    # remove trailing comma and close @entry
+    out = out.rstrip(',') + '\n}'
+
+    highbitwarning = '''
+%%% contains utf-8, see: http://inspirehep.net/info/faq/general#utf8
+%%% add \usepackage[utf8]{inputenc} to your latex preamble
+
+'''
+    # FIXME: transcribe chars above \u007F to TeX sequence ?
+    # if re.search(ur'[\u0080-\uFFFF]', out, re.UNICODE):
+    #     out = highbitwarning + out
+    try:
+        out.decode('ascii')
+    except UnicodeDecodeError:
+        out = highbitwarning + out
+
     return out
 
 
@@ -311,11 +512,13 @@ def format_bibtex_field(name, value, name_width=20, value_width=40):
     """
     Formats a name and value to display as BibTeX field.
 
-    'name_width' is the width of the name of the field (everything before " = " on first line)
+    'name_width' is the width of the name of the field
+    (everything before " = " on first line)
     'value_width' is the width of everything after " = ".
 
-    6 empty chars are printed before the name, then the name and then it is filled with spaces to meet
-    the required width. Therefore name_width must be > 6 + len(name)
+    6 empty chars are printed before the name, then the name and then
+    it is filled with spaces to meet the required width. Therefore
+    name_width must be > 6 + len(name)
 
     Then " = " is printed (notice spaces).
 
@@ -324,8 +527,9 @@ def format_bibtex_field(name, value, name_width=20, value_width=40):
 
     if value is empty string, then return empty string.
 
-    For example format_bibtex_field('author', 'a long value for this record', 13, 15) will
-    return :
+    For example:
+    format_bibtex_field('author', 'a long value for this record', 13, 15)
+    will return :
     >>
     >>      name    = "a long value
     >>                 for this record",
@@ -337,21 +541,21 @@ def format_bibtex_field(name, value, name_width=20, value_width=40):
     if value is None or value == "":
         return ""
 
-    #format name
-    name = "\n      "+name
+    # format name
+    name = "\n      " + name
     name = name.ljust(name_width)
 
-    #format value
-    value = '"'+value+'"' #Add quotes to value
+    # format value
+    value = '"'+value+'"'  # Add quotes to value
     value_lines = []
     last_cut = 0
-    cursor = value_width -1 #First line is smaller because of quote
+    cursor = value_width - 1  # First line is smaller because of quote
     increase = False
     while cursor < len(value):
-        if cursor == last_cut: #Case where word is bigger than the max
-                               #number of chars per line
+        if cursor == last_cut:  # Case where word is bigger than the max
+                                # number of chars per line
             increase = True
-            cursor = last_cut+value_width-1
+            cursor = last_cut + value_width - 1
 
         if value[cursor] != " " and not increase:
             cursor -= 1
@@ -362,15 +566,16 @@ def format_bibtex_field(name, value, name_width=20, value_width=40):
             last_cut = cursor
             cursor += value_width
             increase = False
-    #Take rest of string
+    # Take rest of string
     last_line = value[last_cut:]
-    if last_line != "":
+    if last_line:
         value_lines.append(last_line)
 
     tabs = "".ljust(name_width + 2)
     value = ("\n"+tabs).join(value_lines)
 
     return name + ' = ' + value + ","
+
 
 def get_name(string):
     """
@@ -388,8 +593,8 @@ def get_name(string):
     names = string.split(',')
 
     if len(names) == 1:
-        #Comma not found.
-        #Split around any space
+        # Comma not found.
+        # Split around any space
         longest_name = ""
         words = string.split()
         for word in words:
@@ -418,6 +623,7 @@ def get_year(date, default=""):
 
     return default
 
+
 def get_month(date, ln=CFG_SITE_LANG, default=""):
     """
     Returns the year from a textual date retrieved from a record
@@ -431,13 +637,13 @@ def get_month(date, ln=CFG_SITE_LANG, default=""):
     from invenio.dateutils import get_i18n_month_name
     from invenio.messages import language_list_long
 
-    #Look for textual month like "Jan" or "sep" or "November" or "novem"
-    #Limit to CFG_SITE_LANG as language first (most probable date)
-    #Look for short months. Also matches for long months
+    # Look for textual month like "Jan" or "sep" or "November" or "novem"
+    # Limit to CFG_SITE_LANG as language first (most probable date)
+    # Look for short months. Also matches for long months
     short_months = [get_i18n_month_name(month).lower()
-                    for month in range(1, 13)] # ["jan","feb","mar",...]
+                    for month in range(1, 13)]  # ["jan","feb","mar",...]
     short_months_pattern = re.compile(r'('+r'|'.join(short_months)+r')',
-                                      re.IGNORECASE) # (jan|feb|mar|...)
+                                      re.IGNORECASE)  # (jan|feb|mar|...)
     result = short_months_pattern.search(date)
     if result is not None:
         try:
@@ -446,8 +652,8 @@ def get_month(date, ln=CFG_SITE_LANG, default=""):
         except:
             pass
 
-    #Look for month specified as number in the form 2004/03/08 or 17 02 2004
-    #(always take second group of 2 or 1 digits separated by spaces or - etc.)
+    # Look for month specified as number in the form 2004/03/08 or 17 02 2004
+    # (always take second group of 2 or 1 digits separated by spaces or - etc.)
     month_pattern = re.compile(r'\d([\s]|[-/.,])\
     +(?P<month>(\d){1,2})([\s]|[-/.,])')
     result = month_pattern.search(date)
@@ -458,18 +664,18 @@ def get_month(date, ln=CFG_SITE_LANG, default=""):
         except:
             pass
 
-    #Look for textual month like "Jan" or "sep" or "November" or "novem"
-    #Look for the month in each language
+    # Look for textual month like "Jan" or "sep" or "November" or "novem"
+    # Look for the month in each language
 
-    #Retrieve ['en', 'fr', 'de', ...]
+    # Retrieve ['en', 'fr', 'de', ...]
     language_list_short = [x[0]
                            for x in language_list_long()]
-    for lang in language_list_short: #For each language
-        #Look for short months. Also matches for long months
+    for lang in language_list_short:  # For each language
+        # Look for short months. Also matches for long months
         short_months = [get_i18n_month_name(month, "short", lang).lower()
-                        for month in range(1, 13)] # ["jan","feb","mar",...]
+                        for month in range(1, 13)]  # ["jan","feb","mar",...]
         short_months_pattern = re.compile(r'('+r'|'.join(short_months)+r')',
-                                          re.IGNORECASE) # (jan|feb|mar|...)
+                                          re.IGNORECASE)  # (jan|feb|mar|...)
         result = short_months_pattern.search(date)
         if result is not None:
             try:
@@ -479,5 +685,3 @@ def get_month(date, ln=CFG_SITE_LANG, default=""):
                 pass
 
     return default
-
-

--- a/bibformat/format_elements/bfe_INSPIRE_inproc_booktitle.py
+++ b/bibformat/format_elements/bfe_INSPIRE_inproc_booktitle.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""
+ BibFormat element - Prints bibliographic info for bibtex booktitle associated
+ with a conference record
+
+"""
+
+from invenio.search_engine import get_fieldvalues, search_pattern
+
+
+def format_element(bfo):
+    """
+    Attempt to find a citable conference proceedings "booktitle"
+    for a member record specified by bfo
+    """
+    booktitle = ''
+    # 1) recid:[773__0]  (245 $$a: $$b)
+    recid = bfo.field('773__0')
+    if recid:
+        titles = get_fieldvalues(recid, '245__a')
+        if titles:
+            booktitle = titles[0]
+            subtitles = get_fieldvalues(recid, '245__b')
+            if subtitles:
+                booktitle += ': ' + subtitles[0]
+    # 2) reportnumber of parent record and conference acronym
+    if not booktitle:
+        rn = bfo.field('773__r')
+        if rn:
+            acronym = bfo.field('773__q')
+            if acronym:
+                booktitle = "%s: %s" % (rn, acronym,)
+            # 2.b) reportnumber:[773__r] (245 $$a: $$b)
+            else:
+                recids = search_pattern(p="reportnumber:%s" % (rn,))
+                if recids:
+                    titles = get_fieldvalues(recids[0], '245__a')
+                    if titles:
+                        booktitle = titles[0]
+                        subtitles = get_fieldvalues(recids[0], '245__b')
+                        if subtitles:
+                            booktitle += ': ' + subtitles[0]
+    # 3) 773__w:[773__w] 980:PROCEEDINGS  (245 $$a: $$b)
+    if not booktitle:
+        cnum = bfo.field("773__w")
+        if cnum:
+            cnum = cnum.replace("/", "-")
+            recids = search_pattern(
+                p='773__w:%s 980__a:PROCEEDINGS' % (cnum,))
+            if recids:
+                titles = get_fieldvalues(recids[0], '245__a')
+                if titles:
+                    booktitle = titles[0]
+                    subtitles = get_fieldvalues(recid, '245__b')
+                    if subtitles:
+                        booktitle += ': ' + subtitles[0]
+            # 3.b) 111__g:[773__w] 980:CONFERENCES 111 fields
+            if not booktitle:
+                confrecids = search_pattern(
+                    p="111__g:%s 980__a:CONFERENCES" % (cnum,))
+                if confrecids:
+                    # take first match here
+                    cr = confrecids[0]
+                    titles = get_fieldvalues(cr, '111__a')
+                    subtitles = get_fieldvalues(cr, '111__b')
+                    acronyms = get_fieldvalues(cr, '111__e')
+                    places = get_fieldvalues(cr, '111__c')
+                    if titles:
+                        booktitle = titles[0]
+                        if subtitles:
+                            booktitle += ": " + subtitles[0]
+                    if acronyms:
+                        booktitle += ' %s' % ' '.join(
+                            ('(%s)' % x for x in acronyms))
+                    if places:
+                        booktitle += ' %s' % ', '.join(
+                            (str(x) for x in places))
+                    # 3.c) no 111? -> 773__x in the conf record
+                    if not booktitle:
+                        titles = get_fieldvalues(cr, '773__x')
+                        if titles:
+                            booktitle = ', '.join(titles)
+                    # 3.d) cr -> append date
+                    if booktitle:
+                        from invenio.bibformat_elements import \
+                            bfe_INSPIRE_Conference_cite_date as ccdate
+                        from invenio.bibformat_engine import BibFormatObject
+                        confdate = ccdate.format_element(BibFormatObject(cr))
+                        if confdate:
+                            booktitle += ', ' + confdate
+    # 4) [773__x]
+    if not booktitle:
+        xtitles = bfo.fields('773__x', repeatable_subfields_p=True)
+        if xtitles:
+            booktitle = ', '.join(xtitles)
+
+    return booktitle
+
+
+# we know the argument is unused, thanks
+# pylint: disable=W0613
+def escape_values(bfo):
+    """
+    Called by BibFormat in order to check if output of this element
+    should be escaped.
+    """
+    return 0
+# pylint: enable=W0613

--- a/bibformat/format_elements/bfe_texkey.py
+++ b/bibformat/format_elements/bfe_texkey.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -42,10 +42,10 @@ def get_spires_texkey(bfo):
         source = keys.get('9')
         if source and source in ('SPIRESTeX', 'INSPIRETeX'):
             texkey = keys.get('a')
-            if texkey:
-                return texkey
-            else:
-                texkey = keys.get('z','')
+            if not texkey:
+                texkey = keys.get('z', '')
+    # some keys incorrectly contain whitespace
+    texkey = texkey.replace(' ', '')
     return texkey
 
 def get_generated_texkey(bfo):

--- a/bibformat/format_templates/INSPIRE_BibTeX.bft
+++ b/bibformat/format_templates/INSPIRE_BibTeX.bft
@@ -1,6 +1,5 @@
-<name>BibTeX</name>
-<description>Creates BibTeX format of a record.</description>
-
+<name>INSPIRE_BibTeX</name>
+<description>Creates BibTeX format of a record without its abstract</description>
 <pre>
-<BFE_INSPIRE_BIBTEX width="80" />
+<BFE_INSPIRE_BIBTEX width="80" show_abstract="False" />
 </pre>

--- a/bibformat/format_templates/INSPIRE_BibTeX_abstract.bft
+++ b/bibformat/format_templates/INSPIRE_BibTeX_abstract.bft
@@ -1,0 +1,5 @@
+<name>INSPIRE_BibTeX_abstract</name>
+<description>Creates BibTeX format of a record including its abstract</description>
+<pre>
+<BFE_INSPIRE_BIBTEX width="80" show_abstract="True" />
+</pre>

--- a/bibformat/output_formats/HXA.bfo
+++ b/bibformat/output_formats/HXA.bfo
@@ -1,0 +1,1 @@
+default: INSPIRE_BibTeX_abstract.bft


### PR DESCRIPTION
  Multiple improvements, among them:

  * spaces between author initials
  * spaces in journal names
  * correct @entry type:
    @article, @inproceedings, @inbook, @book, @phdthesis etc.
  * multiple pubnotes delegated to note field
  * bibtex date regex fix
  * multiple bug fixes
  * increased author limit to 10
  * removed trailing comma
  * corrected SLACCITATION
  * correct placement of Jr, IV etc.
  * Russian Yu within {\relax }
  * improved @inproceedings
  * collaboration field omits word collaboration
  * JHEP vol. number problem fixed
  * flake8 compliance
  * initial ISBN support
  * url support, filtered by extension
  * escape special TeX chars in title
  * booktitle support
  * introduces a format element for bibliographic information
    on "booktitle" of parent record to be used in BibTeX format
    of ConferencePapers
  * introduces a format element for date of conferences to be used
    in booktitle for @inproceedings entries
  * bfe_INSPIRE_Conferences_date cosmetics:flake8

  Based on initial work done by Rob Atkinson, however this is a
  major rewrite and refactoring.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>