### PR TITLE
BibFormat: transitional conf detailed display fix

### DIFF
--- a/bibformat/format_templates/Conf_HTML_detailed.bft
+++ b/bibformat/format_templates/Conf_HTML_detailed.bft
@@ -25,6 +25,7 @@ Contributions</a><br />
 <BFE_INSPIRE_EMAIL prefix="Email: " suffix="<br />" />
 
 <BFE_FIELD prefix="<br />"  instances_separator=" " suffix="<br />"  tag="520a" escape="">
+<BFE_FIELD prefix=""  instances_separator=" " suffix="<br />"  tag="500a" escape="">
 <BFE_FIELD prefix=""  instances_separator=" " suffix="<br />"  tag="500o" escape="">
 <BFE_FIELD prefix=""  instances_separator=" " suffix="<br />"  tag="6531a" escape="">
 <BFE_FIELD prefix=""  instances_separator=" " suffix="<br />"  tag="773x" escape="">


### PR DESCRIPTION
Kirsten is moving 500__o to 500__a for Conference collection. This patch adjusts detailed display template to display both fields. Once the metadata update is complete, 500__o should be removed from the template.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>