### PR TITLE
BibCheck: add texkey rule

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -29,6 +29,11 @@ check = earliest_date
 check = mvtexkey_a2z
 filter_collection = HEP
 
+[texkey_exists_035a]
+check = texkey
+filter_pattern = -980__a:Withdrawn -980__a:Deleted
+filter_collection = HEP
+
 [expand_subject]
 check = expand_subject
 filter_collection = HEP


### PR DESCRIPTION

This rule uses the texkey plugin to check that there is a texkey in 035__a. 

There is a related bibsched task, which runs /opt/cds-invenio/bin/bibtex to generate texkeys for records without any, however it does a quick search of provenance field 035__9 and does not distinguish between a texkey in 035__a and 035__z. 

To ensure there is a texkey in 035__a requires record parsing. That's what the texkey plugin does.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>