### PR TITLE
BibCheck: add texkey rule

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -29,6 +29,12 @@ check = earliest_date
 check = mvtexkey_a2z
 filter_collection = HEP
 
+[texkey_exists_035a]
+check = texkey
+filter_pattern = -980__a:Withdrawn -980__a:Deleted
+filter_collection = HEP
+check.extra_subfields = [["9", "INSPIRETeX"]]
+
 [expand_subject]
 check = expand_subject
 filter_collection = HEP


### PR DESCRIPTION

This rule ensures that there is a valid texkey in 035__a with provenance SPIRESTeX or INSPIRETeX and otherwise generates one. 

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>