### PR TITLE
BibTaskLet: consyn harvest urlescape

### DIFF
--- a/bibtasklets/bst_consyn_harvest.py
+++ b/bibtasklets/bst_consyn_harvest.py
@@ -194,6 +194,7 @@ def bst_consyn_harvest(feed_url=None, package=None, feed_file=None,
             if not exists(package):
                 index = package_list.index(package)
                 link = links[index]
+                link = link.replace(' ', '%20')
                 try:
                     message = ("Downloading %s to %s\n" % (link,
                                                            package))
@@ -339,6 +340,7 @@ def download_feed(feed_url, batch_size, delete_zip, new_sources,
             write_message("Not downloading %s, already found %s in %s\n" %
                           (fileUrl, existing_files[0], outFilename))
         else:
+            fileUrl = fileUrl.replace(' ', '%20')
             try:
                 write_message("Downloading %s to %s\n" % (fileUrl,
                                                           outFilename))


### PR DESCRIPTION

Elsevier started using URL containing spaces around 11/2/2015.

e.g.

2015-11-09 21:38:07 --> Downloading http://consyn-delivery-prod.s3.amazonaws.com/nonbulk/AHoltkamp/47331/47331-00001-FULL-XML-NUCL PHYS B (0550-3213) 23.06.ZIP?AWSAccessKeyId=AKIAISTWDGCH3XJI3NIQ&Expires=1447681528&Signature=Y7rillZqNYhDWju44St6BA%2bwrbE%3d to /afs/cern.ch/project/inspire/uploads/elsevier/consyn/47331-00001-FULL-XML-NUCL PHYS B (0550-3213) 23.06.ZIP

This patch converts all spaces in the url string to '%20'.

A more robust fix is to change miscutil/lib/filedownloadutils.py to use urllib.quote() on all but the domain part of the url.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>