### PR TITLE
BibTaskLet: ignore empty cnum

### DIFF
--- a/bibtasklets/bst_cnumcatchup.py
+++ b/bibtasklets/bst_cnumcatchup.py
@@ -46,10 +46,12 @@ def bst_cnumcatchup():
     cnums = []
     for r in confupd:
         for c in get_fieldvalues(r, '111__g'):
-            cnums.append(c)
+            if len(c) > 3:
+                cnums.append(c)
     for r in procupd:
         for c in get_fieldvalues(r, '773__w'):
-            cnums.append(c)
+            if len(c) > 3:
+                cnums.append(c)
 
     recs = intbitset()
     for cn in cnums:


### PR DESCRIPTION
Bad metadata can lead to many matches. In particular an empty field 773__w:"" will trigger a global reformat, since the search matches all records. Avoid this by ensuring that the cnum field is longer than 3 characters

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>