### PR TITLE
BibFormat: hidden fields in XME

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_enhanced_marcxml.py
+++ b/bibformat/format_elements/bfe_INSPIRE_enhanced_marcxml.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -24,6 +24,8 @@ from invenio.search_engine import perform_request_search
 from invenio.bibrank_citation_indexer import get_tags_config as _get_tags_config, get_recids_matching_query
 from invenio.refextract_linker import find_doi, find_journal, find_reportnumber, find_book, find_isbn
 from invenio.dbquery import run_sql
+from invenio.access_control_engine import acc_authorize_action
+from invenio.config import CFG_BIBFORMAT_HIDDEN_TAGS
 
 INSTITUTION_CACHE = {}
 def get_institution_ids(text):
@@ -120,6 +122,13 @@ def format_element(bfo, oai=0):
          693/710 $0 with Record ID of corresponding experiment
     """
     record = bfo.get_record()
+    # Let's filter hidden fields
+    if acc_authorize_action(bfo.user_info, 'runbibedit')[0]:
+        # not authorized
+        for tag in CFG_BIBFORMAT_HIDDEN_TAGS:
+            if tag in record:
+                del record[tag]
+
     recid = bfo.recID
 
     if '100' in record or '700' in record:

--- a/bibtasklets/bst_dump_records.py
+++ b/bibtasklets/bst_dump_records.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of INSPIRE.
-## Copyright (C) 2015 CERN.
+## Copyright (C) 2015, 2016 CERN.
 ##
 ## INSPIRE is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -55,7 +55,7 @@ def bst_dump_records():
         output = gzip.open(output_path, "w")
         print >> output, "<collection>"
         for recid in get_collection_reclist(collection):
-            print >> output, print_record(recid, 'xm', user_info={})
+            print >> output, print_record(recid, 'xme', user_info={})
         print >> output, "</collection>"
         output.close()
         write_message("Computing checksum")

--- a/bibtasklets/bst_prodsync.py
+++ b/bibtasklets/bst_prodsync.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of INSPIRE.
-## Copyright (C) 2015 CERN.
+## Copyright (C) 2015, 2016 CERN.
 ##
 ## INSPIRE is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -42,11 +42,14 @@ from invenio.bibtask import task_update_progress, write_message, task_sleep_now_
 
 from invenio.intbitset import intbitset
 
+from invenio.webuser import collect_user_info, get_uid_from_email, get_email_from_username
+
 import redis
 
 import gzip
 import zlib
 
+ADMIN_USER_INFO = collect_user_info(get_uid_from_email(get_email_from_username('admin')))
 
 CFG_OUTPUT_PATH = "/afs/cern.ch/project/inspire/PROD/var/tmp-shared/prodsync"
 
@@ -87,10 +90,10 @@ def bst_prodsync(method='afs'):
     write_message("Adding %s new or modified records" % tot)
     for i, recid in enumerate(modified_records):
         if method == 'redis':
-            r.rpush('legacy_records', zlib.compress(format_record(recid, 'xme')[0]))
+            r.rpush('legacy_records', zlib.compress(format_record(recid, 'xme', user_info=ADMIN_USER_INFO)[0]))
             # Client should simply use http://redis.io/commands/lpop
         else:
-            print >> r, format_record(recid, 'xme')[0]
+            print >> r, format_record(recid, 'xme', user_info=ADMIN_USER_INFO)[0]
         time_estimation = time_estimator()[1]
         if (i + 1) % 100 == 0:
             task_update_progress("%s (%s%%) -> %s" % (recid, (i + 1) * 100 / tot, time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time_estimation))))


### PR DESCRIPTION
* Respects CFG_BIBFORMAT_HIDDEN_TAGS configuration within the XME
  format, thus effectively hiding hidden fields to unauthorized users
  exporting in the INSPIRE enhanced format.

* Amends bst_prodsync to dump record as superadmin.

* Amends bst_dump_records to dump records in XME format.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>