### PR TITLE
BibFormat: show issue number in pubnote

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_Hep_Erratum.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hep_Erratum.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2016 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -47,10 +47,21 @@ def format_element(bfo):
             tmpout.append(pubinfo.get('v', None))
             if 'y' in pubinfo:
                 tmpout.append('(%s)' % (pubinfo.get('y'),))
+            if number:
+                if number[0].isdigit():
+                    tmpout.append('no.%s,' % number)
+                else:
+                    tmpout.append('%s,' % number)
             tmpout.append(pubinfo.get('c', None))
-            out.append("<strong>%s</strong>" % (" ".join([a for a in tmpout if a]),))
-        if 'x' in pubinfo and ("In *".lower() in pubinfo['x'].lower() or "Also in *".lower() in pubinfo['x'].lower()):
+            out.append("<strong>%s</strong>" % (
+                " ".join([a for a in tmpout if a]),))
+        if 'x' in pubinfo and ("In *".lower() in pubinfo['x'].lower() or
+                               "Also in *".lower() in pubinfo['x'].lower()):
             out.append("<small>%s</small>" % (pubinfo['x'],))
+    # remove dups, preserve order
+    seen = set()
+    seen_add = seen.add
+    out = [x for x in out if x not in seen and not seen_add(x)]
 
     return newline.join(out)
 


### PR DESCRIPTION
    * display issue number after year in pubnote
    * avoid duplicate pubnotes from repeat metadata

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>

This introduces issue number to the pubnote in the detailed record display. The format element is somewhat misnamed as bfe_INSPIRE_Hep_Erratum.py . In fact it displays all pubnotes.

It probably should be combined with bfe_INSPIRE_publi_info.py, which is used for brief and latex formats. I don't know why it was split off. 

Effect is visible here:
http://inspireheptest.cern.ch/search?p=773__n%3A%2F.*%2F&cc=HEP&f=&sf=earliestdate&so=d&of=hd&rg=250

Also avoiding duplicate pubnote from when MARC tag 773 is inadvertently repeated in the metadata e.g. http://inspirehep.net/record/55886 vs http://inspireheptest.cern.ch/record/55886

