### PR TITLE
BibFormat: fix text_Latex_CV improvements

### DIFF
--- a/bibformat/format_templates/text_Latex_CV.bft
+++ b/bibformat/format_templates/text_Latex_CV.bft
@@ -10,8 +10,9 @@ same relationship.</description>
   \\{}<BFE_INSPIRE_AUTHORS limit='8' separator=', ' extension=" {\it et al.}" name_last_first="no" print_links="no" suffix="." markup='latex'/><BFE_INSPIRE_ARXIV links="no" category="yes" prefix="
   \\{}"/><BFE_INSPIRE_LATEX_DOI prefix="
   \\{}" escape="10" /><BFE_INSPIRE_PUBLI_INFO style="us" markup="latex" prefix="
-  \\{}" suffix=""/> %(<BFE_INSPIRE_DATE>)
-%\href{<BFE_SERVER_INFO var="absoluterecurl" escape="10" />}{HEP entry}
+  \\{}" suffix=""/>
+%(<BFE_INSPIRE_DATE>)
+%\href{<BFE_SERVER_INFO var="absoluterecurl" />}{HEP entry}
 <BFE_INSPIRE_CITATION_NUMBER_LATEX prefix="%", suffix="" />
 
 


### PR DESCRIPTION
* Following Thorsten's suggestions, no longer escapes URL and put
  inspire_date on a dedicated line.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>