### PR TITLE
BibFormat: standalone erratum pubnote display

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_Hep_Erratum.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hep_Erratum.py
@@ -55,8 +55,8 @@ def format_element(bfo):
                 else:
                     tmpout.append('%s,' % number)
             tmpout.append(pubinfo.get('c', None))
-            if erratum.lower() in ['erratum', 'addendum', 'reprint', 'corrigendum',
-                                   'publisher-note']:
+            if len(pubinfos) > 1 and erratum.lower() in ['erratum', 'addendum', 'reprint',
+                                                         'corrigendum', 'publisher-note']:
                 errata.append("%s: %s" % (
                     erratum.capitalize(), " ".join([a for a in tmpout if a]),))
             else:


### PR DESCRIPTION
Inspire has a few records which are standalone errata or addenda. In those cases the pubnote should be printed normally. This improves on 2ed6b49