### PR TITLE
BibFormat: add repno to cv-ltx format

### DIFF
--- a/bibformat/format_elements/bfe_report_numbers.py
+++ b/bibformat/format_elements/bfe_report_numbers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2016 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -36,7 +36,7 @@ def format_element(bfo, separator=', ', limit='9999', extension=" etc.", just_on
            skip=['arXiv'], just_one=just_one)
 
 
-def get_report_numbers_formatted(bfo, separator, limit, extension=" etc.", skip=None, just_one=False):
+def get_report_numbers_formatted(bfo, separator, limit, extension=" etc.", skip=None, just_one=False, prefix='', suffix=''):
     """
     Prints the report numbers of the record (037__a and 088__a)
 
@@ -73,10 +73,13 @@ def get_report_numbers_formatted(bfo, separator, limit, extension=" etc.", skip=
         if 'a' in x:
             out.append(x['a'])
 
+    if not out:
+        return
+
     if limit.isdigit() and int(limit) <= len(out):
-        return separator.join(out[:int(limit)]) + extension
+        return prefix + separator.join(out[:int(limit)]) + extension + suffix
     else:
-        return separator.join(out)
+        return prefix + separator.join(out) + suffix
 
 def build_report_number_link(report_number, link_p=True):
     """

--- a/bibformat/format_templates/text_Latex_CV.bft
+++ b/bibformat/format_templates/text_Latex_CV.bft
@@ -9,10 +9,9 @@ same relationship.</description>
 {\bf ``<BFE_INSPIRE_TITLE_BRIEF  force_title_case="yes" esctitle="4" />''}
   \\{}<BFE_INSPIRE_AUTHORS limit='8' separator=', ' extension=" {\it et al.}" name_last_first="no" print_links="no" suffix="." markup='latex'/><BFE_INSPIRE_ARXIV links="no" category="yes" prefix="
   \\{}"/><BFE_INSPIRE_LATEX_DOI prefix="
-  \\{}" escape="10" /><BFE_INSPIRE_PUBLI_INFO style="us" markup="latex" prefix="
-  \\{}" suffix=""/>
+  \\{}DOI:" escape="10" /><BFE_INSPIRE_PUBLI_INFO style="us" markup="latex" prefix="
+  \\{}" suffix=""/><BFE_REPORT_NUMBERS prefix="
+  \\{}" limit="9999" separator=', ' />
 %(<BFE_INSPIRE_DATE>)
 %\href{<BFE_SERVER_INFO var="absoluterecurl" />}{HEP entry}
 <BFE_INSPIRE_CITATION_NUMBER_LATEX prefix="%", suffix="" />
-
-


### PR DESCRIPTION

requested by LHCb to include report numbers in the CV format

https://app.asana.com/0/3728178550980/131426425272078

this patch unconditionally adds report numbers up to limit="9999". I also added a DOI: prefix to the doi, when present.

I seriously looked at utilizing BFE_INSPIRE_PUBLI_INFO_LATEX  to replace DOI, pubnote, arXiv, repno elements, but the amount of necessary tweaks is excessive.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>