### PR TITLE
BibFormat: default repno is empty string

### DIFF
--- a/bibformat/format_elements/bfe_report_numbers.py
+++ b/bibformat/format_elements/bfe_report_numbers.py
@@ -74,7 +74,7 @@ def get_report_numbers_formatted(bfo, separator, limit, extension=" etc.", skip=
             out.append(x['a'])
 
     if not out:
-        return
+        return ''
 
     if limit.isdigit() and int(limit) <= len(out):
         return prefix + separator.join(out[:int(limit)]) + extension + suffix


### PR DESCRIPTION

previous commit changed behavior from returning empty string to returning None
this reverts that change

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>