### PR TITLE
BibCheck: replace en-dash with hyphen

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -87,3 +87,10 @@ filter_pattern = 980__a:ConferencePaper and (8564_u:'jacow.org' or 8564_u:'accel
 filter_collection = HEP
 check.field = "999C5i"
 
+[endash_to_hyphen]
+check = regexp_replace
+filter_collection = HEP
+filter_pattern = 773:*–*
+check.fields = ["773__c", "773__n", "773__p", "773__v", "773__x"]
+check.find = "–"
+check.replace = "-"


### PR DESCRIPTION
    * rule to replace en-dash in page-range (773__c)
      with hyphen

Note that plugin regexp_replace doesn't handle unicode strings for patterns and using unicode character classes doesn't seem possible. It would be better to handle a wider range of hyphen equivalents, e.g. en- and em-dash and others
ur'[\u2010-\u2014]'. The parsing of bibcheck rule options does not appear to allow for that.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>