### PR TITLE
BibCheck: convert U+2019 to U+0027 in author name

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -101,3 +101,11 @@ filter_collection = HEP
 filter_pattern = 037__a:/123-QED/
 check.patterns = ["HEP-123-QED", "APS-123-QED", "APS/123-QED", "AIP-123-QED"]
 check.fields = ["037__a"]
+
+[author-apostrophe]
+check = regexp_replace
+filter_collection = HEP
+filter_pattern = 100__a:'’' OR 700__a:'’'
+check.fields = ["100__a", "700__a"]
+check.find = "’"
+check.replace = "'"


### PR DESCRIPTION
    * normalizes author names to use ascii apostrophe instead
      of unicode right single quotation mark for unambiguous
      search and author profile -- even though U+2019 is
      typographically preferred

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>