### PR TITLE
BibCheck: remove rule for isbn in refs

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -81,12 +81,6 @@ check = add_alice_inspireid
 filter_collection = HEP
 filter_pattern = find cn alice
 
-[rm_isbn_from_jacow_refs]
-check = delete_subfield_filter
-filter_pattern = 980__a:ConferencePaper and (8564_u:'jacow.org' or 8564_u:'accelconf.web.cern.ch')
-filter_collection = HEP
-check.field = "999C5i"
-
 [endash_to_hyphen]
 check = regexp_replace
 filter_collection = HEP


### PR DESCRIPTION
Kirsten's unwanted rule removed

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>