### PR TITLE
bibedit: add ORCID to templates

### DIFF
--- a/bibedit/record_article.xml
+++ b/bibedit/record_article.xml
@@ -32,6 +32,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
   </datafield>
@@ -81,6 +82,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="700" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
   </datafield>

--- a/bibedit/record_book.xml
+++ b/bibedit/record_book.xml
@@ -36,6 +36,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="e">VOLATILE:ed.</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>

--- a/bibedit/record_book_chapter.xml
+++ b/bibedit/record_book_chapter.xml
@@ -28,6 +28,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
   </datafield>

--- a/bibedit/record_conference_paper.xml
+++ b/bibedit/record_conference_paper.xml
@@ -36,6 +36,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
   </datafield>
@@ -88,6 +89,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="700" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
   </datafield>

--- a/bibedit/record_data_template.xml
+++ b/bibedit/record_data_template.xml
@@ -25,9 +25,9 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
-	  <subfield code="j">VOLATILE:External author ID</subfield>
   </datafield>
   <datafield tag="245" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Original title</subfield>

--- a/bibedit/record_preprint.xml
+++ b/bibedit/record_preprint.xml
@@ -31,6 +31,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
   </datafield>
@@ -75,6 +76,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="700" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
   </datafield>

--- a/bibedit/record_proceedings.xml
+++ b/bibedit/record_proceedings.xml
@@ -36,6 +36,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
     <subfield code="e">VOLATILE:ed.</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
   </datafield>

--- a/bibedit/record_thesis.xml
+++ b/bibedit/record_thesis.xml
@@ -39,6 +39,7 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:Familyname, Firstname</subfield>
+    <subfield code="j">VOLATILE:ORCID:</subfield>
     <subfield code="m">VOLATILE:email</subfield>
     <subfield code="u">VOLATILE:Affiliation</subfield>
   </datafield>

--- a/bibedit/volatile_check_HEP.xml_ignore
+++ b/bibedit/volatile_check_HEP.xml_ignore
@@ -34,6 +34,9 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="e">VOLATILE:ed.</subfield>
   </datafield>
+  <datafield tag="100" ind1=" " ind2=" ">
+    <subfield code="j">VOLATILE:ORCID:</subfield>
+  </datafield>
   <datafield tag="300" ind1=" " ind2=" ">
     <subfield code="a">VOLATILE:999</subfield>
   </datafield>
@@ -51,6 +54,9 @@ along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
   </datafield>
   <datafield tag="700" ind1=" " ind2=" ">
     <subfield code="e">VOLATILE:ed.</subfield>
+  </datafield>
+  <datafield tag="700" ind1=" " ind2=" ">
+    <subfield code="j">VOLATILE:ORCID:</subfield>
   </datafield>
   <datafield tag="773" ind1=" " ind2=" ">
     <subfield code="m">VOLATILE:Erratum</subfield>

--- a/bibedit/volatile_check_data.xml_ignore
+++ b/bibedit/volatile_check_data.xml_ignore
@@ -4,6 +4,9 @@
   <datafield tag="024" ind1="7" ind2=" ">
     <subfield code="2">VOLATILE:DOI</subfield>
   </datafield>
+  <datafield tag="100" ind1=" " ind2=" ">
+    <subfield code="j">VOLATILE:ORCID:</subfield>
+  </datafield>
   <datafield tag="336" ind1=" " ind2=" ">
     <subfield code="t">VOLATILE:DATASET</subfield>
   </datafield>


### PR DESCRIPTION
* Adds volatile fields for ORCIDs in templates.

Signed-off-by: fschwenn <florian.schwennsen@desy.de>