### PR TITLE
prodsync: sync records from latest to earliest

### DIFF
--- a/bibtasklets/bst_prodsync.py
+++ b/bibtasklets/bst_prodsync.py
@@ -85,9 +85,9 @@ def bst_prodsync(method='afs'):
     time_estimator = get_time_estimator(tot)
     write_message("Adding %s new or modified records" % tot)
     if method == 'afs':
-        afs_sync(modified_records, time_estimator, tot, now)
+        afs_sync(reversed(modified_records), time_estimator, tot, now)
     else:
-        redis_sync(modified_records, time_estimator, tot)
+        redis_sync(reversed(modified_records), time_estimator, tot)
     open(lastrun_path, "w").write(future_lastrun)
     write_message("DONE!")
 


### PR DESCRIPTION
* Reverses the order of records being synced, so that one can
  quickly have latest records already in the dump.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>