### PR TITLE
BibFormat: no more OSTI links in 8564

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_links.py
+++ b/bibformat/format_elements/bfe_INSPIRE_links.py
@@ -129,7 +129,7 @@ def format_element(bfo, default='', separator='; ', style='',
     allowed_doctypes = ["INSPIRE-PUBLIC", "SCOAP3", "PoS"]
     for url in urls:
         if url.get("y", "").lower() not in \
-           ("adsabs", "euclid", "msnet", "zblatt"):
+           ("adsabs", "euclid", "msnet", "osti", "zblatt"):
             if '.png' not in url.get('u', '') and not (
                     url.get('y', '').lower().startswith("fermilab") and
                     bfo.field("710__g").lower() in


### PR DESCRIPTION
OSTI links were replaced with corresponding identifiers in 035
There should be no more OSTI links in 8564 (once Heath finishes the cleanup of the remaining leftovers). This ensures that leftover links are skipped and no inadvertent double linking from 035 and 8564 happens.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>