### PR TITLE
BibRank: adds alternate pubinfo field

### DIFF
--- a/bibrank/citation.cfg
+++ b/bibrank/citation.cfg
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2011 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2011, 2016 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -31,6 +31,7 @@ pubinfo_journal_title = 773__p
 pubinfo_journal_volume = 773__v
 pubinfo_journal_year = 773__y
 pubinfo_journal_format = "p,v,c"
+pubinfo_alternate = 7731_
 first_author = 100__a
 additional_author = 700__a
 alternative_author_name = 720__a


### PR DESCRIPTION
This introduces a secondary or alternate pubinfo with the same structure as the regular pubinfo. It is intended for variations or alternate forms that should not be displayed or exposed to the user, however they are used by bibrank for citation matching. An accompanying PR will be issued for the invenio repo.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>