### PR TITLE
BibFormat: urlescape links in Experiments HD format

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_exp_acronym.py
+++ b/bibformat/format_elements/bfe_INSPIRE_exp_acronym.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2016 CERN.
+## Copyright (C) 2016 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -16,24 +16,24 @@
 ## You should have received a copy of the GNU General Public License
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
-"""BibFormat element - Prints full-text URLs
+
+"""BibFormat element - Prints Name/Acronym of Experiemnt
 """
 
 from urllib import quote_plus
 
 
-def format_element(bfo, style, separator=', '):
+def format_element(bfo, urlescape=False):
     """
-    This is the default format for formatting full-text URLs.
-    @param separator: the separator between urls.
-    @param style: CSS class of the link
+    return Experiment name/acronym, optionally escape for use in URLs
+    e.g. SNO+ -> SNO%2B
     """
 
-    urls = bfo.fields("710__g")
+    acronym = bfo.field("119__a")
 
-    urls = ['<a href="/search?p=collaboration:%27' + quote_plus(url) + '%27">'
-            + url +'</a>' for url in urls]
-    return separator.join(urls)
+    if urlescape:
+        acronym = quote_plus(acronym)
+    return acronym
 
 
 # pylint: disable=W0613

--- a/bibformat/format_templates/Exp_HTML_brief.bft
+++ b/bibformat/format_templates/Exp_HTML_brief.bft
@@ -12,7 +12,7 @@
 
 <small>
 <BFE_INSPIRE_URL prefix="" suffix="<br />" default="" escape="" style="" separator="; "/>
-<a href="/search?ln=en&p=693__e%3A<BFE_FIELD tag='119__a'/>">HEP articles associated with <BFE_FIELD tag="119__a"/></a>
+<a href="/search?p=693__e%3A<BFE_INSPIRE_EXP_ACRONYM urlescape='1'/>">HEP articles associated with <BFE_INSPIRE_EXP_ACRONYM/></a>
 <BFE_INSPIRE_EXP_COLLABORATION prefix="<br />"/>
 
 </small>

--- a/bibformat/format_templates/Exp_HTML_detailed.bft
+++ b/bibformat/format_templates/Exp_HTML_detailed.bft
@@ -16,9 +16,9 @@
 
 <BFE_FIELD prefix="<br />" suffix="<br />" tag="520a" escape="">
 <br />
-<a href="/search?ln=en&p=693__e%3A<BFE_FIELD tag='119__a'/>">HEP articles associated with <BFE_FIELD tag="119__a"/></a><br />
-<a href="/search?ln=en&cc=HepNames&p=693__e%3A<BFE_FIELD tag='119__a'/>">Collaboration members in HepNames</a><br />
-<a href="/search?ln=en&ln=en&p=693__e%3A<BFE_FIELD tag='119__a'/>&of=hcs">Citesummary</a>
+<a href="/search?p=693__e%3A<BFE_INSPIRE_EXP_ACRONYM urlescape='1'/>">HEP articles associated with <BFE_INSPIRE_EXP_ACRONYM/></a><br />
+<a href="/search?cc=HepNames&amp;p=693__e%3A<BFE_INSPIRE_EXP_ACRONYM urlescape='1'/>">Collaboration members in HepNames</a><br />
+<a href="/search?p=693__e%3A<BFE_INSPIRE_EXP_ACRONYM urlescape='1'/>&amp;of=hcs">Citesummary</a>
 <BFE_INSPIRE_EXP_RELATED prefix="<br />Related Experiments: " /><br />
 <BFE_INSPIRE_EXP_COLLABORATION prefix="<br />"/>
 


### PR DESCRIPTION
    * properly escapes search string
    * introduces new format element for exp acronym
    * removes unwanted ln=en parameter
    * fixes HTML errors

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>


This is in response to a user complaint about the incorrect links for the SNO+ experiment, i.e. 
https://inspirehep.net/record/1108233
where the searches are not properly urlescaping the '+'


