### PR TITLE
BibCheck: rule to remove empty fields

### DIFF
--- a/bibcheck/notimechange-rules.cfg
+++ b/bibcheck/notimechange-rules.cfg
@@ -8,3 +8,6 @@ check.fields = ["%%%%%%"]
 check = useful_hepname
 filter_collection = HepNames
 filter_pattern = -980__a:USEFUL
+
+[emptyfields]
+check = remove_empty_fields


### PR DESCRIPTION

runs plugin `remove_empty_fields` on HEP and HepNames with `--notimechange`

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>