### PR TITLE
BibCheck: geocode Conferences

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -108,3 +108,7 @@ check.replace = "'"
 check = sort_family_names
 filter_pattern = 100__a:/^[^,]$|(,\s*.+\s+.+|,\s*(\w\.)+\w\w+)[^\.]$/ or 700__a:/^[^,]$|(,\s*.+\s+.+|,\s*(\w\.)+\w\w+)[^\.]$/
 filter_collection = HEP
+
+[geocode_confs]
+check = geocode_all_the_things
+filter_collection = Conferences


### PR DESCRIPTION
check Conference records for lat/lon coordinates and use google geocode plugin to add them if missing

an initial chunked run was done in order to not exceed google api limits for free access

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>