### PR TITLE
PortalBox: update experiments email

### DIFF
--- a/feedboxes/portalbox-017-Experiments-rt-100.html
+++ b/feedboxes/portalbox-017-Experiments-rt-100.html
@@ -5,8 +5,8 @@
     <h3>Experiments</h3>
      <ul>
       <li><a href="http://www.slac.stanford.edu/spires/experiments/additions.shtml">Additions</a></li>
-      <li><a href="mailto:expwork@slac.stanford.edu">Corrections</a></li>
-      <li><a href="mailto:expwork@slac.stanford.edu">Email Us</a></li>
+      <li><a href="mailto:experiments@inspirehep.net">Corrections</a></li>
+      <li><a href="mailto:experiments@inspirehep.net">Email Us</a></li>
       <li><a href="/info/Experiments/list">Experiment categories</a></li>
       <li><a href="/search?cc=Experiments&amp;p=8564_y%3Atwitter&amp;sf=119__a&amp;so=a&amp;rg=100">Twitter Feeds</a></li>
      </ul>


### PR DESCRIPTION
new gandi email alias was set up today 12/5/2016 for `experiments@inspirehep.net`
RT procmail config was adjusted to route email addressed to `experiments@inspirehep` to `EXP` queue

This patch updates the info on the Experiments portalbox

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>