### PR TITLE
BibCheck: bugfixes in plugin

### DIFF
--- a/bibcheck/plugins/rename_subfield_filter.py
+++ b/bibcheck/plugins/rename_subfield_filter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2013 CERN.
+## Copyright (C) 2013, 2016 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -26,29 +26,33 @@ depending on subfield_filter
 Example:
 [mvtexkey_withSpace]
 check = rename_subfield_filter
-check.source_field = '035__a'
-check.new_code = 'z'
-check.pattern = ' '
-check.complement = False
-check.subfield.filter = ('9','SPIRESTeX')
+filter_collection = HEP
+check.source_field = "035__a"
+check.new_code = "z"
+check.pattern = " "
+check.complement = false
+check.subfield_filter = ["9", "SPIRESTeX"]
 
 [mvtexkey_wrongSyntax]
 check = rename_subfield_filter
-check.source_field = '035__a'
-check.new_code = 'z'
-check.pattern = r'^[A-Za-z]+:\d{4}[a-z]{2,3}$'
-check.complement = True
-check.subfield.filter = ('9','INSPIRETeX')
 filter_collection = HEP
+check.source_field = "035__a"
+check.new_code = "z"
+check.pattern = "^[A-Za-z]+:\\d{4}[a-z]{2,3}$"
+check.complement = true
+check.subfield_filter = ["9", "INSPIRETeX"]
 """
 
+
 def check_record(record, source_field, new_code,
-                 pattern, complement, subfield_filter):
+                 pattern, subfield_filter, complement=False):
     """ Changes the code of a subfield to new_code """
     import re
     from invenio.bibrecord import record_modify_subfield
     assert len(source_field) == 6
     source_field = source_field.replace("_", " ")
+    assert len(subfield_filter) == 2
+    subfield_filter = tuple(subfield_filter)
     for pos, val in record.iterfield(source_field, subfield_filter):
         pattern_matches = re.search(pattern, val)
         if (pattern_matches and not complement) or \


### PR DESCRIPTION
    * correcting docstring examples
    * rules.cfg is parsed as json
      - use double quotes for string
      - true/false instead of True/False
      - no tuples, lists instead
      - r' ' for pattern does not work
    * casting subfield_filter to tuple

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>