### PR TITLE
BibCheck: superseeded recid replacement rule

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -117,3 +117,8 @@ filter_collection = Conferences
 check = type_code
 filter_collection = HEP
 filter_pattern = 773__y:1900->3000 -980__a:Proceedings -980__a:Introductory
+
+[superseeded_ref]
+check = superseeded_refs
+filter_collection = HEP
+filter_pattern = 999C50:**


### PR DESCRIPTION
check  and replace recids in 999C50 if the target record was deleted and superseed with new recid

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>