### PR TITLE
BibCheck: fix doi lookup

### DIFF
--- a/bibcheck/plugins/refcheck.py
+++ b/bibcheck/plugins/refcheck.py
@@ -94,7 +94,7 @@ class Reference(object):
                 hits |= search_unit(f='reportnumber', p=val)
         elif key == 'DOI':
             for val in self._fields[key][pos]:
-                hits |= search_unit(f='doi', p=val)
+                hits |= search_unit(f='doi', p=val, m='a')
 
         return hits & HEPRECS
 


### PR DESCRIPTION

`search_unit(f='doi', p=val)` fails because `get_index_id_from_field('doi')` returns `0`

`search_unit(f='doi', p=val, m='a')` works because it uses `get_field_tags(f)` in addition 

I think that's a problem in search.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>