### PR TITLE
BibFormat: cvlatex usability

### DIFF
--- a/bibformat/format_templates/text_Latex_CV.bft
+++ b/bibformat/format_templates/text_Latex_CV.bft
@@ -14,4 +14,4 @@ same relationship.</description>
   \\{}" limit="9999" separator=', ' />
 %(<BFE_INSPIRE_DATE>)
 %\href{<BFE_SERVER_INFO var="absoluterecurl" />}{HEP entry}
-<BFE_INSPIRE_CITATION_NUMBER_LATEX prefix="%", suffix="" />
+<BFE_INSPIRE_CITATION_NUMBER_LATEX prefix="%Citations: ", suffix="" />


### PR DESCRIPTION
* Improves usability of CVLaTeX output format by prefixing citation
  line with: "%Citations: " to make it easy to our user to search and
  enable the line.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>