### PR TITLE
BibFilter: handle relative PDF URLs

### DIFF
--- a/bibharvest/bibfilter_oaipos2inspire.py
+++ b/bibharvest/bibfilter_oaipos2inspire.py
@@ -36,6 +36,7 @@ from tempfile import mkdtemp
 from os import remove
 from os.path import (join,
                      basename)
+from urlparse import urljoin
 from shutil import copy
 from bs4 import BeautifulSoup
 from datetime import datetime
@@ -108,6 +109,8 @@ def main(args):
         for link in links:
             url = urllib.quote(link['href'], safe=":/")
             if url.endswith('.pdf'):
+                # handle relative URLs
+                url = urljoin(base_url, url)
                 found = True
                 filename = join(out_folder, identifier + ".pdf")
                 record_add_field(rec, '856', ind1='4', subfields=[


### PR DESCRIPTION

*PoS* appears to have switched to _relative_ URLs for fulltext (PDF) source, e.g. https://pos.sissa.it/contribution?id=PoS(unesp2002)001
has in the HTML source:
```
<p>Contribution: <a href="/archive/conferences/008/001/unesp2002_001.pdf">pdf</a></p>
```
so in order to download those PDF files `https://pos.sissa.it` needs to be prepended. 

For example look at bibsched log 

/opt/cds-invenio/var/log/bibsched/44/bibsched_task_444800.log

```
Traceback (most recent call last):
  File "/opt/cds-invenio/bin/bibfilter_oaipos2inspire.py", line 207, in <module>
    main(sys.argv[1:])
  File "/opt/cds-invenio/bin/bibfilter_oaipos2inspire.py", line 122, in main
    download_url(url, "pdf", filename, 5, 60.0)
  File "/usr/lib64/python2.6/site-packages/invenio/filedownloadutils.py", line 110, in download_url
    download_to_file)
  File "/usr/lib64/python2.6/site-packages/invenio/filedownloadutils.py", line 293, in download_local_file
    raise InvenioFileCopyError(msg)
invenio.filedownloadutils.InvenioFileCopyError: Impossible to copy the local file '/archive/conferences/008/001/unesp2002_001.pdf' to /afs/cern.ch/project/inspire/uploads/pos/2017.01.23-1/PoS(unesp2002)001.pdf: 
```



Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>