### PR TITLE
bibcheck: new plugin - ref_jvolume

### DIFF
--- a/bibcheck/plugins/ref_jvolume.py
+++ b/bibcheck/plugins/ref_jvolume.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2013 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""
+For journal reference field 999C5s
+move letter in front of volume if volume > vol_min or volume < vol_max
+"""
+def check_record(record, journal, letter, vol_min=0, vol_max=999999):
+    """
+    Move volume letter in front of volume
+    """
+    import re
+    jvol = re.compile("^(?P<journal>%s,)(?P<volume>\d+) *%s(?P<pages>,.*)$" %
+        (re.escape(journal), re.escape(letter)))
+
+    for position, jref in record.iterfield("999C5s"):
+        result = jvol.search(jref)
+        if result:
+            volume = result.group('volume')
+            if vol_min < int(volume) and int(volume) < vol_max:
+                new_jref = result.group('journal') + letter + volume + result.group('pages')
+                record.amend_field(position, new_jref)
+

--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -122,3 +122,11 @@ filter_pattern = 773__y:1900->3000 -980__a:Proceedings -980__a:Introductory
 check = superseeded_refs
 filter_collection = HEP
 filter_pattern = 999C50:**
+
+[ref_volume_PLB]
+check = ref_jvolume
+filter_pattern = 999C5s:"Phys.Lett.,*B,*"
+filter_collection = HEP
+check.journal= "Phys.Lett."
+check.letter = "B"
+check.vol_min = 169


### PR DESCRIPTION
* moves letter before volume number in references for given journal in volume-range
* similar fix for PLA as soon as 773 is cleaned
* the first time this HAS TO RUN WITH NOTIMECHANGE

Signed-off-by: Kirsten Sachs <kirsten.sachs@desy.de>