### PR TITLE
BibTaskLets: ensure request timeout

### DIFF
--- a/bibharvest/bibfilter_oaipos2inspire.py
+++ b/bibharvest/bibfilter_oaipos2inspire.py
@@ -32,6 +32,7 @@ import sys
 import requests
 import urllib
 
+from requests.exceptions import ConnectionError, Timeout
 from tempfile import mkdtemp
 from os import remove
 from os.path import (join,
@@ -101,7 +102,12 @@ def main(args):
 
         url = base_url + identifier
         session = requests.session()
-        r = session.get(url)
+        try:
+            r = session.get(url, timeout=60)
+        except ConnectionError, Timeout:
+            register_exception()
+            error_records.append(rec)
+            continue
         parsed_html = BeautifulSoup(r.text)
         links = parsed_html.body.findAll('a')
         found = False

--- a/bibtasklets/bst_scoap3_importer.py
+++ b/bibtasklets/bst_scoap3_importer.py
@@ -38,7 +38,7 @@ from invenio.bibtask import task_low_level_submission, write_message, task_sleep
 def bst_scoap3_importer():
     """Import from SCOAP3."""
     try:
-        request = requests.get('http://repo.scoap3.org/ffts_for_inspire.py/csv')
+        request = requests.get('http://repo.scoap3.org/ffts_for_inspire.py/csv', timeout=60)
     except (HTTPError, ConnectionError, Timeout):
         register_exception()
         return


### PR DESCRIPTION
@kaplun 
this is a followup to HAL timeout already merged
https://github.com/inspirehep/inspire/pull/284

I looked for other uses of requests.get() without specified timeout and added these two. Also https://github.com/inspirehep/inspire/pull/284 could maybe be improved with a try/except ?


Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>