### PR TITLE
BibFormat: fix xme uninitialized var

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_enhanced_marcxml.py
+++ b/bibformat/format_elements/bfe_INSPIRE_enhanced_marcxml.py
@@ -182,6 +182,7 @@ def format_element(bfo, oai=0):
 
     is_institution = 'INSTITUTION' in [collection.upper() for collection in bfo.fields('980__a')]
 
+    signatures = {}
     if '100' in record or '700' in record:
         signatures = dict((name, (personid, flag)) for name, personid, flag in run_sql("SELECT name, personid, flag FROM aidPERSONIDPAPERS WHERE bibrec=%s AND flag>-2", (recid, )))
 


### PR DESCRIPTION

avoid errors from uninitialized variable.

here's an error from an Institution record which has no MARC `100` or `700`. it only has a spokesperson MARC `702`

```
* 2017-06-06 01:53:40 -> UnboundLocalError: local variable 'signatures' referenced before assignment (bfe_INSPIRE_enhanced_marcxml.py:201:format_element)

** User details
No client information available

** Traceback details

Traceback (most recent call last):
  File "/usr/lib64/python2.6/site-packages/invenio/bibformat_engine.py", line 718, in eval_format_element
    output_text = function(**params)
  File "/usr/lib64/python2.6/site-packages/invenio/bibformat_elements/bfe_INSPIRE_enhanced_marcxml.py", line 201, in format_element
    personid, flag = signatures.get(author_name, (None, None))
UnboundLocalError: local variable 'signatures' referenced before assignment

** Stack frame details

Frame format_element in /usr/lib64/python2.6/site-packages/invenio/bibformat_elements/bfe_INSPIRE_enhanced_marcxml.py at line 201
-------------------------------------------------------------------------------
       198                     subfields.append(('x', '%i' % hepname_id))
       199                     subfields.append(('y', '1'))
       200             else:
---->  201                 personid, flag = signatures.get(author_name, (None, None))
       202                 bai = get_personid_canonical_id().get(personid)
       203                 if bai:
       204                     subfields.append(('w', bai))
-------------------------------------------------------------------------------
                      record =  "{'650': [([('a', 'ASTRO-PH')], '1', '7', '', 6)], '980': [([('a', 'EXPERIMENT')], ' ', ' ', '', 11)], '909': [([('o', 'oai:inspirehep.net:1339331'), ('p', 'INSPIRE:Experiments')], 'C', 'O', '', 10)], '702': [([('a', 'Zhen Cao')], ' ', ' ', '', 8)], '710': [([('g', 'LHAASO')], ' ', ' ', '', 9)], '245': [([('a', 'Large High Altitude Air Shower Observatory')], ' ', ' ', '', 4)], '001': [([], ' ', ' ', '1339331', 1)], '520': [([('a', 'The LHAASO project will use a 1 km2 array composed of electron d [...]
              is_institution =  'False'
                         bfo =  "<BibFormatObject(recid=1339331,lang='en',search_pattern=[],output_format='xme',user_info={'uid': 1L, 'agent': '', 'precached_viewclaimlink': False, 'session': None, 'precached_useadmin': False, 'group': [], 'guest': '0', 'websearch_latestbox': 1, 'precached_usepaperattribution': False, 'precached_usepaperclaim': False, 'precached_viewsubmissions': False, 'precached_usegroups': False, 'email': 'admin@inspire-hep.net', 'precached_usealerts': False, 'precached_usestats': False, 'precached_usemessa [...]
                  collection =  "'EXPERIMENT'"
                  bibrecdocs =  'BibRecDocs(1339331)'
                       field =  "([('a', 'Zhen Cao')], ' ', ' ', '', 8)"
        can_see_hidden_stuff =  'True'
               subfield_dict =  "{'a': 'Zhen Cao'}"
                 author_name =  "'Zhen Cao'"
                       recid =  '1339331'
                         oai =  '0'
                   subfields =  "[('a', 'Zhen Cao')]"
```


Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>