### PR TITLE
PortalBoxes: hepdata link update

### DIFF
--- a/feedboxes/portalbox-002-HEP-rt-100.html
+++ b/feedboxes/portalbox-002-HEP-rt-100.html
@@ -30,7 +30,7 @@
      <ul>
       <li><a href="http://adswww.harvard.edu">ADS</a></li>
       <li><a href="http://arXiv.org">arXiv</a></li>
-      <li><a href="http://hepdata.cedar.ac.uk/">HepData</a></li>
+      <li><a href="https://hepdata.net/">HepData</a></li>
       <li><a href="http://www.iaea.org/inis">INIS</a></li>
       <li><a href="http://pdg.lbl.gov">PDG</a></li>
       <li><a href="https://library.web.cern.ch/library/rpp/">PDG review of online resources</a></li>

--- a/feedboxes/portalbox-004-Jobs-rt-100.html
+++ b/feedboxes/portalbox-004-Jobs-rt-100.html
@@ -25,7 +25,7 @@
     <h3>Resources</h3>
      <ul>
       <li><a href="http://www.arXiv.org">arXiv</a></li>
-      <li><a href="http://hepdata.cedar.ac.uk/">HEPDATA</a></li>
+      <li><a href="https://hepdata.net/">HEPDATA</a></li>
       <li><a href="http://pdg.lbl.gov">PDG</a></li>
      </ul>
    </td>

--- a/feedboxes/portalbox-017-Experiments-rt-100.html
+++ b/feedboxes/portalbox-017-Experiments-rt-100.html
@@ -23,7 +23,7 @@
 
     <h3>Resources</h3>
      <ul>
-      <li><a href="http://hepdata.cedar.ac.uk/">HEPDATA</a></li>
+      <li><a href="https://hepdata.net/">HEPDATA</a></li>
       <li><a href="http://pdg.lbl.gov">PDG</a></li>
       <li><a href="http://www.phy.bnl.gov/newphysics/experiments.html">Brookhaven Natl. Lab. Experiments</a></li>
       <li><a href="http://greybook.cern.ch/">CERN Greybook</a></li>

--- a/feedboxes/portalbox-019-Journals-rt-100.html
+++ b/feedboxes/portalbox-019-Journals-rt-100.html
@@ -20,7 +20,7 @@
     <h3>Resources</h3>
      <ul>
       <li><a href="http://www.arXiv.org">arXiv</a></li>
-      <li><a href="http://hepdata.cedar.ac.uk/">HEPDATA</a></li>
+      <li><a href="https://hepdata.net/">HEPDATA</a></li>
       <li><a href="http://pdg.lbl.gov">PDG</a></li>
      </ul>
    </td>


### PR DESCRIPTION
Updating the HepData link in portalboxes. The old site is redirecting to https://hepdata.net/

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>