### PR TITLE
BibCheck: rule add doi prefix

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -130,3 +130,11 @@ filter_collection = HEP
 check.journal= "Phys.Lett."
 check.letter = "B"
 check.vol_min = 169
+
+[doiprefixinref]
+check = regexp_replace
+filter_collection = HEP
+filter_pattern = 999C5a:/^10\.[0-9]{4}/
+check.fields = ["999C5a"]
+check.find = "^(?i)(?<!doi:)\\s*(10[.][0-9]{4,}(?:[.][0-9]+)*/(?:(?![\"&\\'<>])\\S)+)\\b"
+check.replace = "doi:\\1"


### PR DESCRIPTION
normalize DOIs in `999C5a` to include `doi:` prefix

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>