### PR TITLE
BibFormat: arXiv link syntax quirks

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_Hepnames_Arxiv.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hepnames_Arxiv.py
@@ -23,5 +23,9 @@ def format_element(bfo):
     position = out.find('_')
     if position >= 0:
         out = out[:position+2]
+    out = out.replace('-', '_')
+    out = out.replace("'", "")
+    if out.find(' ') > -1:
+        out = out.rsplit(" ", 1)[1]
     out = translate_to_ascii([out]).pop()
     return out


### PR DESCRIPTION
arXiv author search normalizes names in quirky ways. This patch 

    * drops `'`
    * replaces `-` with `_`
    * takes only the final part of multi-part last names

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>