### PR TITLE
cds: match also based on 595__a:CDS-*

### DIFF
--- a/bibharvest/bibfilter_oaicds2inspire.py
+++ b/bibharvest/bibfilter_oaicds2inspire.py
@@ -873,7 +873,7 @@ def field_swap_subfields(field, subs):
 
 def attempt_record_match(recid):
     """ Tries to find out if the record is already in Inspire """
-    return perform_request_search(p="035:CDS and 035:%s" % (recid,), of="id")
+    return perform_request_search(p="(035:CDS and 035:%s) or 595__a:CDS-%s" % (recid, recid), of="id", ap=-9)
 
 
 def is_published(record):


### PR DESCRIPTION
* When harvesting from CDS, matches incoming record not only on
  035__9:CDS but also 595__a:CDS-*.
  (closes #342)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>