### PR TITLE
bibtasklet: serialize in JSON

### DIFF
--- a/bibtasklets/bst_claimsync.py
+++ b/bibtasklets/bst_claimsync.py
@@ -2,6 +2,7 @@ from time import strftime
 
 import sys, os
 import redis
+import json
 
 from invenio.config import CFG_REDIS_HOST_LABS, CFG_TMPSHAREDDIR
 from invenio.bibformat_elements.bfe_INSPIRE_enhanced_marcxml import get_hepname_id, get_personid_canonical_id
@@ -63,7 +64,7 @@ def bst_claimsync():
             if bai:
                 hepname_id = get_hepname_id(personid)
                 if hepname_id:
-                    r.rpush(REDIS_KEY, (bai, hepname_id, bibrec, name, flag))
+                    r.rpush(REDIS_KEY, json.dumps((bai, hepname_id, bibrec, name, flag)))
                 else:
                     write_message("Skipping claim %s because no hepname_id corresponds to it" % ((bai, personid, bibrec, name, flag),), stream=sys.stderr)
             else:

--- a/bibtasklets/bst_orcidsync.py
+++ b/bibtasklets/bst_orcidsync.py
@@ -21,6 +21,7 @@
 """Continuously synchronizes ORCID tokens to Labs via REDIS"""
 
 import redis
+import json
 
 try:
     from invenio.config import CFG_REDIS_HOST_LABS
@@ -54,7 +55,7 @@ def bst_orcidsync():
     # We first empty the information
     r.ltrim(CFG_REDIS_ORCID_SYNC_KEY, -1, 0)
     for orcid, token, email, name in orcid_data_to_sync():
-        r.lpush(CFG_REDIS_ORCID_SYNC_KEY, (orcid, token, email, name))
+        r.lpush(CFG_REDIS_ORCID_SYNC_KEY, json.dumps((orcid, token, email, name)))
     write_message("%s ORCID entries pushed to Labs" % r.llen(CFG_REDIS_ORCID_SYNC_KEY))
     return True
 


### PR DESCRIPTION
* When pushing information (such as ORCID tokens and claims) via
  Redis, serializes it via JSON.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>