### PR TITLE
XME: export correct doctype

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_enhanced_marcxml.py
+++ b/bibformat/format_elements/bfe_INSPIRE_enhanced_marcxml.py
@@ -174,7 +174,7 @@ def format_element(bfo, oai=0):
                 ('n', bibdocfile.name or ''),
                 ('r', bibdocfile.status or ''),
                 ('s', bibdocfile.cd.strftime('%Y-%m-%d %H:%M:%S')),
-                ('t', bibdocfile.get_type()),
+                ('t', bibdocfile.bibdoc.doctype),
                 ('v', str(bibdocfile.version)),
                 ('z', bibdocfile.comment or ''),
             ]


### PR DESCRIPTION
* Workaround bug on legacy and do export correct doctype in
  XME format. (Closes #310)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>