### PR TITLE
BibFormat: urlescape # in DOIs

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_doi.py
+++ b/bibformat/format_elements/bfe_INSPIRE_doi.py
@@ -30,7 +30,7 @@ def format_element(bfo, tag="0247_,773__", separator=", ", link_prefix='http://d
         fields = bfo.fields(a_tag)
         for field in fields:
             if (a_tag == "773__" or field.get('2', 'DOI') == 'DOI') and 'a' in field:
-                output.append('<a href="' + link_prefix + field['a'] + '">' + field['a'] + '</a>')
+                output.append('<a href="' + link_prefix + field['a'].replace('#', '%23') + '">' + field['a'] + '</a>')
     return separator.join(set(output))
 
 


### PR DESCRIPTION
some DOIs have a `#` which needs to be urlescaped for the link to `dx.doi.org`

this affects only 14 records as of 2017-12-01

```
466698 10.1002/(SICI)1521-3978(199901)47:1/3<125::AID-PROP125>3.0.CO;2-#
554481 10.1002/1521-3978(200108)49:8/9<869::AID-PROP869>3.0.CO;2-#
599654 10.1002/1521-3978(200209)50:8/9<878::AID-PROP878>3.0.CO;2-#
496866 10.1002/(SICI)1521-3978(200005)48:5/7<637::AID-PROP637>3.3.CO;2-#
568701 10.1002/1521-3978(200209)50:8/9<896::AID-PROP896>3.0.CO;2-#
582254 10.1002/1521-3978(200209)50:8/9<959::AID-PROP959>3.0.CO;2-#
483665 10.1002/(SICI)1521-3978(20001)48:1/3<155::AID-PROP155>3.0.CO;2-#
483503 10.1002/(SICI)1521-3978(20001)48:1/3<191::AID-PROP191>3.0.CO;2-#
500750 10.1002/1521-3889(200009)9:8<589::AID-ANDP589>3.0.CO;2-#
482515 10.1002/(SICI)1521-3978(20001)48:1/3<119::AID-PROP119>3.0.CO;2-#
530885 10.1002/1521-3978(200102)49:1/3<3::AID-PROP3>3.0.CO;2-#
588801 10.1002/1521-3978(200209)50:8/9<986::AID-PROP986>3.0.CO;2-#
589975 10.1002/1521-3978(200205)50:5/7<675::AID-PROP675>3.0.CO;2-#
480966 10.1002/(SICI)1521-3978(20001)48:1/3<209::AID-PROP209>3.0.CO;2-#
```


Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>