### PR TITLE
WebSubmit: bibtex tool fix

### DIFF
--- a/websubmit/Bibtex.py
+++ b/websubmit/Bibtex.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2004, 2005, 2006, 2007, 2008, 2010, 2011 CERN.
+## Copyright (C) 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2018 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -15,7 +15,6 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-__revision__ = "$Id$"
 
 import os
 import re
@@ -136,7 +135,7 @@ def process_references(references, output_format):
                     formated_rec = format_record(recid_list[0], \
                                                  output_format, 'en')
                     # update bibitem and cite if they don't match
-                    if not re.search('bibitem{' + ref + '}', formated_rec):
+                    if not re.search('bibitem{' + re.escape(ref) + '}', formated_rec):
                         ref = re.sub(',', '.', ref)
                         if output_format != 'hx':
                             #laTeX
@@ -148,7 +147,7 @@ def process_references(references, output_format):
                                                   formated_rec)
                         else:
                             #bibtex
-                            if not re.search(r'\@article\{' + ref + '}', \
+                            if not re.search(r'\@article\{' + re.escape(ref) + '}', \
                                              formated_rec):
                                 formated_rec = re.sub(r'\@article\{(.*)\,', \
                                                       r'@article{' + ref + ',', \


### PR DESCRIPTION
fix for unsafe user input to `re`, in particular it also addresses a problem with texkeys containing unmatched `)` etc.

e.g.
```
In [13]: Bibtex.process_references(['IPTA):2013lea'], 'hx')
---------------------------------------------------------------------------
error                                     Traceback (most recent call last)
<ipython-input-13-f6a569bace66> in <module>()
----> 1 Bibtex.process_references(['IPTA):2013lea'], 'hx')

/usr/lib64/python2.6/site-packages/invenio/websubmit_functions/Bibtex.py in process_references(references, output_format)
    137                                                  output_format, 'en')
    138                     # update bibitem and cite if they don't match
--> 139                     if not re.search('bibitem{' + ref + '}', formated_rec):
    140                         ref = re.sub(',', '.', ref)
    141                         if output_format != 'hx':

/usr/lib64/python2.6/re.pyc in search(pattern, string, flags)
    140     """Scan through string looking for a match to the pattern, returning
    141     a match object, or None if no match was found."""
--> 142     return _compile(pattern, flags).search(string)
    143 
    144 def sub(pattern, repl, string, count=0):

/usr/lib64/python2.6/re.pyc in _compile(*key)
    243         p = sre_compile.compile(pattern, flags)
    244     except error, v:
--> 245         raise error, v # invalid expression
    246     if len(_cache) >= _MAXCACHE:
    247         _cache.clear()

error: unbalanced parenthesis
```

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>