### PR TITLE
BibFormat: remove space after aff in HEP detailed

### DIFF
--- a/bibformat/format_templates/Default_HTML_detailed.bft
+++ b/bibformat/format_templates/Default_HTML_detailed.bft
@@ -14,7 +14,7 @@ highlight="yes" brief="no" />
 <BFE_INSPIRE_AUTHORS suffix="<br />" limit=25 interactive="yes"
 print_affiliations="yes" affiliations_separator=' &amp; ' separator=', '
 limit="10" extension="<i> et al.</i>" name_last_first="no"
-affiliation_prefix="<small> (" affiliation_suffix=") </small>" />
+affiliation_prefix="<small> (" affiliation_suffix=")</small>" />
 
 <p style="font-size: 90%">
 <BFE_INSPIRE_DATEPAGE prefix="" suffix=""/>


### PR DESCRIPTION
remove errant space after affiliation enclosed in parens

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>