### PR TITLE
BibFormat: add missing separator in authors

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_authors.py
+++ b/bibformat/format_elements/bfe_INSPIRE_authors.py
@@ -3,7 +3,7 @@
 ## $Id$
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2011, 2015, 2016 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2011, 2015, 2016, 2018 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -379,12 +379,12 @@ def format_element(
             more = separator + separator.join(authors[1:]) + ')'
         else:
             show = separator.join(authors[:int(limit)])
-            more = separator.join(authors[int(limit):len(authors)])
+            more = separator + separator.join(authors[int(limit):len(authors)])
 
         out += show
-        out += ' <span id="more" style="">' + more + '</span>'
-        out += ' <span id="extension"></span>'
-        out += ' <small><i><a id="link" href="#"' + \
+        out += '<span id="more" style="">' + more + '</span>'
+        out += '<span id="extension"></span>'
+        out += '&nbsp;&nbsp;<small><i><a id="link" href="#"' + \
                ' style="color:green;background:white;" onclick="toggle_authors_visibility()" ' + \
                ' style="color:rgb(204,0,0);"></a></i></small>'
         out += '<script>set_up()</script>'

--- a/bibformat/format_templates/Default_HTML_detailed.bft
+++ b/bibformat/format_templates/Default_HTML_detailed.bft
@@ -13,7 +13,7 @@ highlight="yes" brief="no" />
 <BFE_FIELD tag="242__a" suffix="<br />" />
 <BFE_INSPIRE_AUTHORS suffix="<br />" limit=25 interactive="yes"
 print_affiliations="yes" affiliations_separator=' &amp; ' separator=', '
-limit="10" extension="<i> et al.</i>" name_last_first="no"
+limit="10" extension="<i> et&nbsp;al.</i>" name_last_first="no"
 affiliation_prefix="<small> (" affiliation_suffix=")</small>" />
 
 <p style="font-size: 90%">


### PR DESCRIPTION
ensure there is a separator at the continuation point between authors before and after expansion of long author lists 

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>