### PR TITLE
BibTasklets: send record to prodsync on BAI change

### DIFF
--- a/bibtasklets/bst_prodsync.py
+++ b/bibtasklets/bst_prodsync.py
@@ -98,6 +98,8 @@ def bst_prodsync(method='afs', with_citations='yes', with_claims='yes', skip_col
                     modified_records.add(citer)
             if with_claims.lower() == 'yes':
                 modified_records |= intbitset(run_sql("SELECT bibrec FROM aidPERSONIDPAPERS WHERE last_updated>=%s", (last_run, )))
+                modified_records |= intbitset(run_sql("SELECT bibrec FROM aidPERSONIDPAPERS AS p JOIN aidPERSONIDDATA as d"
+                                                      " ON p.personid = d.personid WHERE d.last_updated>=%s", (last_run, )))
     except IOError:
         # Default to everything
         with run_ro_on_slave_db():


### PR DESCRIPTION
recids of HepNames associated to a signature get exposed in the XME
format, so a new association of a HepNames to an author profile should
flag all HEP records in that profile for prodsync.

Signed-off-by: Micha Moskovic <michamos@gmail.com>