### PR TITLE
BibTaskLet: avoids redundant scoap3 downloads

### DIFF
--- a/bibtasklets/bst_scoap3_importer.py
+++ b/bibtasklets/bst_scoap3_importer.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of INSPIRE.
-## Copyright (C) 2014 CERN.
+## Copyright (C) 2014, 2018 CERN.
 ##
 ## INSPIRE is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -93,7 +93,13 @@ def bst_scoap3_importer():
                 if doc.checksum == checksum:
                     write_message("... OK: file alredy attached to INSPIRE record %s (doc.checksum=%s, checksum=%s)" % (inspire_record, doc.checksum, checksum))
                 else:
-                    write_message("... OK: new revision available for INSPIRE record %s (doc.checksum=%s, checksum=%s)" % (inspire_record, doc.checksum, checksum))
+                    # also check all previous version checksums
+                    allchecksums = set()
+                    for doc in record.list_bibdocs(doctype="SCOAP3"):
+                        for filev in doc.list_all_files():
+                            allchecksums.add(filev.checksum)
+                    if checksum not in allchecksums:
+                        write_message("... OK: new revision available for INSPIRE record %s (doc.checksum=%s, checksum=%s)" % (inspire_record, doc.checksum, checksum))
                     action = "UPDATE"
                 break
         else:


### PR DESCRIPTION

this avoids attaching another revision with the same checksum as any previous revisions, and in particular it addresses flip-flop from having a fulltext and an addendum being alternatingly attached

e.g.

```
$ bibdocfile --get-info -d 2301294 | grep checksum
1396328:2301294:1:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:2:.pdf:checksum=861ad6dc3ae62b6b0dda9f8a0814b602
1396328:2301294:3:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:4:.pdf:checksum=42e57cf8ca19b7eee2c98c6baf408d49
1396328:2301294:5:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:6:.pdf:checksum=42e57cf8ca19b7eee2c98c6baf408d49
1396328:2301294:7:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:8:.pdf:checksum=42e57cf8ca19b7eee2c98c6baf408d49
1396328:2301294:9:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:10:.pdf:checksum=42e57cf8ca19b7eee2c98c6baf408d49
1396328:2301294:11:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:12:.pdf:checksum=42e57cf8ca19b7eee2c98c6baf408d49
1396328:2301294:13:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:14:.pdf:checksum=42e57cf8ca19b7eee2c98c6baf408d49
1396328:2301294:15:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:16:.pdf:checksum=42e57cf8ca19b7eee2c98c6baf408d49
1396328:2301294:17:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:18:.pdf:checksum=42e57cf8ca19b7eee2c98c6baf408d49
1396328:2301294:19:.pdf:checksum=2843dbcdb7e64f49098eed600dd219da
1396328:2301294:20:.pdf:checksum=42e57cf8ca19b7eee2c98c6baf408d49
......
```
and there are actually over 1000 files

```
> ls -al /opt/cds-invenio/var/data/files/g115/2301294/content.pdf\;* | less
-rw-r--r-- 1   32766 apache 441664 Dec 18  2015 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1
-rw-r--r-- 1   32766 apache 152689 May 25  2016 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;10
-rw-r--r-- 1   32766 apache 152689 Aug 24  2016 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;100
-rw-r--r-- 1   32766 apache 152689 Feb 28 14:47 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1000
-rw-r--r-- 1   32766 apache 441732 Mar  1 16:01 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1001
-rw-r--r-- 1   32766 apache 152689 Mar  1 16:03 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1002
-rw-r--r-- 1   32766 apache 441732 Mar  2 15:48 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1003
-rw-r--r-- 1   32766 apache 152689 Mar  2 15:50 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1004
-rw-r--r-- 1   32766 apache 441732 Mar  3 16:22 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1005
-rw-r--r-- 1   32766 apache 152689 Mar  3 16:24 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1006
-rw-r--r-- 1   32766 apache 441732 Mar  4 16:49 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1007
-rw-r--r-- 1   32766 apache 152689 Mar  4 16:50 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1008
-rw-r--r-- 1   32766 apache 441732 Mar  5 17:31 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1009
-rw-r--r-- 1   32766 apache 441664 Aug 25  2016 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;101
-rw-r--r-- 1   32766 apache 152689 Mar  5 17:32 /opt/cds-invenio/var/data/files/g115/2301294/content.pdf;1010
...............
```


```
hschwand@p05153026637155$ pdfinfo '/opt/cds-invenio/var/data/files/g115/2301294/content.pdf;985'
Title:          Updating neutrino magnetic moment constraints
Subject:        Physics Letters B, 753 (2016) 191–198. 10.1016/j.physletb.2015.12.011
Author:         B.C. Cañas
Creator:        Elsevier
Producer:       Acrobat Distiller 9.5.5 (Windows)
CreationDate:   Wed Jan 20 12:47:00 2016
ModDate:        Wed Jan 20 12:47:00 2016
Tagged:         yes
Pages:          8
Encrypted:      no
Page size:      595.276 x 793.701 pts
File size:      441732 bytes
Optimized:      yes
PDF version:    1.7
09:37 PM env:inspire_production_legacy ~ 
hschwand@p05153026637155$ pdfinfo '/opt/cds-invenio/var/data/files/g115/2301294/content.pdf;984'
Title:          Addendum to “Updating neutrino magnetic moment constraints” [Phys. Lett. B 753 (2016) 191–198]
Subject:        Physics Letters B, 757 (2016) 568. 10.1016/j.physletb.2016.03.078
Author:         B.C. Cañas
Creator:        Elsevier
Producer:       Acrobat Distiller 9.5.5 (Windows)
CreationDate:   Fri May 13 13:04:43 2016
ModDate:        Fri May 13 13:04:43 2016
Tagged:         yes
Pages:          1
Encrypted:      no
Page size:      595.276 x 793.701 pts
File size:      152689 bytes
Optimized:      yes
PDF version:    1.7
```


Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>