### PR TITLE
BibCheck: expand_subject for all collections

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -37,7 +37,6 @@ check.extra_subfields = [["9", "INSPIRETeX"]]
 
 [expand_subject]
 check = expand_subject
-filter_collection = HEP
 filter_pattern = 65017a:/^.$/
 
 [correct_dates]


### PR DESCRIPTION
Existing rule expand_subject runs currently on HEP only.
Expand to all collections.

Signed-off-by: Kirsten Sachs <kirsten.sachs@desy.de>