### PR TITLE
BibFormat: skip 110t in Inst display

### DIFF
--- a/bibformat/format_templates/Inst_HTML_brief.bft
+++ b/bibformat/format_templates/Inst_HTML_brief.bft
@@ -6,8 +6,6 @@
 <a class = "titlelink" href= "<BFE_SERVER_INFO var="recurl">">
 <BFE_INSPIRE_INST_TITLE />
 </a> 
-<BFE_FIELD prefix="[Future INSPIRE ID: " suffix="]" default="" escape=""
-extension="" instances_separator=" & " tag="110t"/> 
 </strong>
 <br />
 

--- a/bibformat/format_templates/Inst_HTML_detailed.bft
+++ b/bibformat/format_templates/Inst_HTML_detailed.bft
@@ -3,8 +3,6 @@
 <div class="detailed_record_info"><table width="100%"><tr><td width="70%">
 
 <BFE_INSPIRE_INST_TITLE prefix="<b>" suffix="</b>" />
-<BFE_FIELD prefix="[Future INSPIRE ID: " suffix="]" default="" escape=""
-extension="" instances_separator=" & " tag="110t"/>
 <BFE_FIELD instances_separator=" " prefix="<br />" tag="110a" escape="">
 <BFE_FIELD instances_separator=" " prefix="<br />"  tag="110b" escape="">
 <br />


### PR DESCRIPTION
    * Do not display subfield `110__t` in Institution records 

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>