### PR TITLE
BibFormat: don't use 110__t for child inst

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_inst_children.py
+++ b/bibformat/format_elements/bfe_INSPIRE_inst_children.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2018 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -44,10 +44,7 @@ def format_element(bfo, separator='; '):
         out += "Subsidiary Institution: "
         for item in children:
             # get the abbreviated name of the institution
-            abbrev = BibFormatObject(item).field('110__t')
-            # if there is no abbreviated name, we try different names
-            if not abbrev:
-                abbrev = BibFormatObject(item).field('110__u')
+            abbrev = BibFormatObject(item).field('110__u')
             if not abbrev:
                 abbrev = BibFormatObject(item).field('110__a')
             if not abbrev:


### PR DESCRIPTION
Don't use `110__t` for name of child institution. `110__u` is the appropriate field.
`110__a` is a failsafe in case of bad metadata.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>