### PR TITLE
bibedit: add GRID to volatile_check_institution.xml_ignore

### DIFF
--- a/bibedit/volatile_check_institution.xml_ignore
+++ b/bibedit/volatile_check_institution.xml_ignore
@@ -1,4 +1,7 @@
 <!-- BibEdit-Template-Name: institution -->
 <!-- BibEdit-Template-Description: institution -->
 <record>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="9">VOLATILE:GRID</subfield>
+  </datafield>
 </record>


### PR DESCRIPTION
* Adds 035__9:GRID to volatile_check_institution.xml_ignore to avoid
  removal of it by bibcheck.

Signed-off-by: fschwenn <florian.schwennsen@desy.de>