### PR TITLE
Feedboxes: update HEPNames links

### DIFF
--- a/feedboxes/portalbox-009-HepNames-rt-100.html
+++ b/feedboxes/portalbox-009-HepNames-rt-100.html
@@ -34,12 +34,12 @@
           <li><a href="http://web.anl.gov/directory/">Argonne Natl. Lab.</a></li>
           <li><a href="http://www.bnl.gov/directory/">Brookhaven Natl. Lab.</a></li>
           <li><a href="http://directory.web.cern.ch/directory/">CERN</a></li>
-          <li><a href="http://www.desy.de/pbook?lang=eng">DESY, Hamburg</a></li>
+          <li><a href="http://www.desy.de/about_desy/lead_scientists/index_eng.html">DESY, Hamburg</a></li>
           <li><a href="http://www-tele.fnal.gov/cgi-bin/telephone.script">Fermilab</a></li>
-          <li><a href="http://english.ihep.cas.cn/pe/">IHEP, Beijing</a></li>
-          <li><a href="http://www.jlab.org/search.html">JLab, Newport News</a></li>
-          <li><a href="http://legacy.kek.jp/intra-e/question.html">KEK, Tsukuba</a></li>
-          <li><a href="http://www.stfc.ac.uk/2475.aspx#search">Rutherford Lab.</a></li>
+          <li><a href="http://english.ihep.cas.cn/doc/1946.html">IHEP, Beijing</a></li>
+          <li><a href="https://misportal.jlab.org/mis/staff/staffsearch.cfm">JLab, Newport News</a></li>
+          <li><a href="https://souran.kek.jp/kss/top/">KEK, Tsukuba</a></li>
+          <li><a href="https://stfc.ukri.org/about-us/contact-us/">Rutherford Lab.</a></li>
           <li><a href="http://www-public.slac.stanford.edu/phonebook/search.aspx">SLAC</a></li>
         </ul>
       </li>


### PR DESCRIPTION
-update dead directory links of DESY, IHEP, JLAB, KEK, and Rutherford