### PR TITLE
tasklets: smarter author query in prodsync

### DIFF
--- a/bibtasklets/bst_prodsync.py
+++ b/bibtasklets/bst_prodsync.py
@@ -101,8 +101,8 @@ def bst_prodsync(method='afs', with_citations='yes', with_claims='yes', skip_col
                     modified_records.add(citer)
             if with_claims.lower() == 'yes':
                 modified_records |= intbitset(run_sql("SELECT bibrec FROM aidPERSONIDPAPERS WHERE last_updated>=%s", (last_run, )))
-                modified_records |= intbitset(run_sql("SELECT bibrec FROM aidPERSONIDPAPERS AS p JOIN aidPERSONIDDATA as d"
-                                                      " ON p.personid = d.personid WHERE d.last_updated>=%s", (last_run, )))
+                modified_records |= intbitset(run_sql('SELECT bibrec FROM aidPERSONIDPAPERS AS p JOIN aidPERSONIDDATA as d'
+                                                      ' ON p.personid = d.personid WHERE d.tag = "canonical_name" and d.last_updated>=%s', (last_run, )))
     except IOError:
         # Default to everything
         with run_ro_on_slave_db():


### PR DESCRIPTION
* the XME format contains BAI identifiers of authors, so records need to
be selected for prodsync when the BAI changes. However, other updates to
the aidPERSONIDDATA table are irrelevant, so the query can be restricted
in order to trigger less prodsync activity.

Signed-off-by: Micha Moskovic <michamos@gmail.com>