### PR TITLE
BibCheck: updated fix_inspireid plugin

### DIFF
--- a/bibcheck/plugins/fix_inspireid.py
+++ b/bibcheck/plugins/fix_inspireid.py
@@ -96,7 +96,12 @@ CHANGES = [
     (('u', 'IRFU, Saclay'), ('i', 'INSPIRE-00220215', 'INSPIRE-00657399')),
     (('u', 'DAPNIA, Saclay'), ('i', 'INSPIRE-00220215', 'INSPIRE-00657399')),
     (('a', 'Tudorache, Alexandra'), ('j', 'ORCID:0000-0001-5384-3843', 'ORCID:0000-0001-6307-1437')),
-    (('u', 'Jyvaskyla U.'), ('i', 'INSPIRE-00250377', 'INSPIRE-00493721'))
+    (('u', 'Jyvaskyla U.'), ('i', 'INSPIRE-00250377', 'INSPIRE-00493721')),
+    (('a', 'Zhang, Huaqiao'), ('i', 'INSPIRE-00227070', 'INSPIRE-00227084')),
+    (('i', 'INSPIRE-00317229'), ('a', 'Ahmad, Muhammad', 'Ahmad, Muhammad, 1')),
+    (('i', 'INSPIRE-00365887'), ('a', 'Ahmad, Muhammad', 'Ahmad, Muhammad, 2')),
+    (('i', 'INSPIRE-00536572'), ('a', 'Wang, Jian', 'Wang, Jian, 1')),
+    (('i', 'INSPIRE-00000419'), ('a', 'Wang, Jian', 'Wang, Jian, 2'))
     ]
 
 


### PR DESCRIPTION
    -Added Zhang, Huaqiao (correct INSPIRE-ID) to fix_inspireid.py
    -Added Ahmad, Muhammad (change name to separate author signatures) to fix_inspireid.py
    -Wang, Jian (change name to separate author signatures) to fix_inspireid.py
    -2019-3-22 updated commit to add numerals to names rather than shorten to initials

Signed-off-by: Melissa Clegg <cleggm1@fnal.gov>