### PR TITLE
BibFormat: use https for links to orcid

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_Hepnames_ORCID.py
+++ b/bibformat/format_elements/bfe_INSPIRE_Hepnames_ORCID.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2014, 2015 CERN.
+## Copyright (C) 2014, 2015, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -32,7 +32,7 @@ def format_element(bfo):
             if "http" in orcid:
                 return '<a href="%s">%s</a>' % (orcid, orcid)
             else:
-                link = "http://orcid.org/" + orcid
+                link = "https://orcid.org/" + orcid
                 return '<a href="%s">%s</a>' % (link, orcid)
 
 

--- a/feedboxes/portalbox-009-HepNames-rt-100.html
+++ b/feedboxes/portalbox-009-HepNames-rt-100.html
@@ -47,7 +47,7 @@
       <li><a href="http://genealogy.math.ndsu.nodak.edu/">Mathematics Genealogy Project</a></li>
       <li><a href="http://www.ams.org/mathscinet/searchauthors.html">MathSciNet Author Search</a></li>
       <li><a href="http://scholar.google.com/citations?view_op=search_authors">Google Scholar Author Search</a></li>
-      <li><a href="http://orcid.org/">ORCID</a></li>
+      <li><a href="https://orcid.org/">ORCID</a></li>
      </ul>
    </td>
   </tr>


### PR DESCRIPTION
    * use https for orcid links in HepNames
    * update orcid link in HepNames feedbox to https

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>