### PR TITLE
BibFormat: update match string from Atlas/CMS

### DIFF
--- a/bibformat/format_elements/bfe_report_numbers.py
+++ b/bibformat/format_elements/bfe_report_numbers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2016 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2016, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -57,7 +57,7 @@ def get_report_numbers_formatted(bfo, separator, limit, extension=" etc.", skip=
                    value.get('9', '').lower() == keyword.lower():
                     return True
         if value.get('a', '').lower().startswith("fermilab") and \
-           bfo.field("710__g").lower() in ('atlas collaboration', 'cms collaboration'):
+           bfo.field("710__g").lower() in ('atlas', 'cms', 'atlas collaboration', 'cms collaboration'):
             return True
 
     numbers = bfo.fields("037__")


### PR DESCRIPTION
A while back the `710__g` field was normalized to not contain the word collaboration any longer. This updates the Fermilab report_number exclusion
accordingly.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>