### PR TITLE
WebSubmit: update to Bibtex.py

### DIFF
--- a/websubmit/Bibtex.py
+++ b/websubmit/Bibtex.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2018 CERN.
+## Copyright (C) 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2018, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -113,21 +113,19 @@ def process_references(references, output_format):
             ref = re.sub(r'\.', ',', ref)
         elif re.search(r'\w\-\w', ref):
             index = 'r'
+        elif re.search(r'\d{4}[\w.&]{15}', ref):
+            index = 'ads'
         if index:
             # hack to match more records
             recid_list = ''
-            if index == 'texkey':
-                p_to_find = '035__z:' + ref
+            if index == 'texkey' or index == 'ads':
+                p_to_find = '035:"' + ref + '"'
                 recid_list = perform_request_search(p=p_to_find)
-                if not recid_list:
-                    #try 035__a
-                    p_to_find = '035__a:' + ref
-                    recid_list = perform_request_search(p=p_to_find)
             else:
                 p_to_find = 'find ' + index + ' ' + ref
                 recid_list = perform_request_search(p=p_to_find)
 
-            if recid_list:
+            if len(recid_list) == 1:
                 bfo = BibFormatObject(recid_list[0])
                 if (output_format == 'hlxu' or
                         output_format == 'hlxe' or

--- a/websubmit/bibtex_unit_test.py
+++ b/websubmit/bibtex_unit_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2009, 2010, 2011 CERN.
+## Copyright (C) 2009, 2010, 2011, 2019 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -187,6 +187,32 @@ class TestBibtex(unittest.TestCase):
         refs = Bibtex.get_references(lines)
         ret = Bibtex.process_references(refs, 'hx')
         self.assertTrue(ret.index(r'@article'))
+
+
+    def test_search_adsbibcode(self):
+        """ test case for an ADS bibcode
+
+        """
+        print '\ntest9\n'
+        lines = r"""
+                \cite{2018A&A...615A..71K}
+        """
+        refs = Bibtex.get_references(lines)
+        ret = Bibtex.process_references(refs, 'hx')
+        self.assertTrue(ret.index(r'@article'))
+
+
+    def test_search_not_adsbibcode(self):
+        """ test case for false ADS bibcode
+
+        """
+        print '\ntest10\n'
+        lines = r"""
+                \cite{2018A&A...615A...71K}
+        """
+        refs = Bibtex.get_references(lines)
+        ret = Bibtex.process_references(refs, 'hx')
+        self.assertTrue(ret.index(r'@MISC'))
 
 
 def main():


### PR DESCRIPTION
    -Updated Bibtex.py used in BiblioTools to accept ADS bibcodes as citations
    -Added unit test for ADS bibcodes

Signed-off-by: Melissa Clegg <cleggm1@fnal.gov>