### PR TITLE
WebSubmit: Update bibtex

### DIFF
--- a/websubmit/Bibtex.py
+++ b/websubmit/Bibtex.py
@@ -102,7 +102,9 @@ def process_references(references, output_format):
     nsmsg = '*** Non-standard form, no INSPIRE lookup performed ***'
     for ref in references:
         index = None
-        if re.search(r'.*\:\d{4}\w\w\w?', ref):
+        if re.search(r'\d{4}[\w.&]{15}', ref):
+            index = 'ads'
+        elif re.search(r'.*\:\d{4}\w\w\w?', ref):
             index = 'texkey'
         elif re.search(r'.*\/\d{7}', ref):
             index = 'eprint'
@@ -113,8 +115,6 @@ def process_references(references, output_format):
             ref = re.sub(r'\.', ',', ref)
         elif re.search(r'\w\-\w', ref):
             index = 'r'
-        elif re.search(r'\d{4}[\w.&]{15}', ref):
-            index = 'ads'
         if index:
             # hack to match more records
             recid_list = ''

--- a/websubmit/bibtex_unit_test.py
+++ b/websubmit/bibtex_unit_test.py
@@ -209,11 +209,14 @@ class TestBibtex(unittest.TestCase):
         print '\ntest10\n'
         lines = r"""
                 \cite{2018A&A...615A...71K}
+                \cite{PhysRev.D100.096018}
         """
         refs = Bibtex.get_references(lines)
         ret = Bibtex.process_references(refs, 'hx')
-        self.assertTrue(ret.index(r'@MISC'))
-
+        is_true = '@MISC{2018A&A...615A...71K,' in ret
+        self.assertTrue(is_true)
+        is_true2 = '@article{PhysRev.D100.096018,' in ret
+        self.assertTrue(is_true2)
 
 def main():
     unittest.main()


### PR DESCRIPTION
    -reordered when ads bibcodes are searched
    -avoids falsely identifying journal references as ADS bibcodes
Signed-off-by: Melissa Clegg <cleggm1@fnal.gov>