### PR TITLE
BibFormat: avoid output of only page info

### DIFF
--- a/bibformat/format_elements/bfe_INSPIRE_bibtex.py
+++ b/bibformat/format_elements/bfe_INSPIRE_bibtex.py
@@ -368,7 +368,7 @@ def format_element(bfo, width="50", show_abstract=False):
                 if displaycnt == 0:
                     pagesset = True
                     out += texified("pages", pages)
-                else:
+                elif str773:
                     str773 += ',' + pages.split('-', 1)[0]
 
             if str773:


### PR DESCRIPTION
   * avoid output of "page (year)" only or otherwise incomplete pubnote,
     e.g. a reprint pointer in 773 which has only $0 and $c, or similar

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>