### PR TITLE
WebStyle: redirect Conferences to labs

### DIFF
--- a/bibexport/sitemap.cfg
+++ b/bibexport/sitemap.cfg
@@ -3,7 +3,6 @@ export_method = sitemap
 collection1 = HEP
 collection2 = HepNames
 collection3 = Institutions
-collection4 = Conferences
 collection6 = Experiments
 collection7 = Journals
 export_fulltext = 0

--- a/webstyle/webstyle_templates_inspire.py
+++ b/webstyle/webstyle_templates_inspire.py
@@ -468,7 +468,8 @@ $(function () {
 ::
 <a id="nav-inst" href="%(siteurl)s/collection/Institutions">Institutions</a>
 ::
-<a id="nav-conf" href="%(siteurl)s/collection/Conferences">Conferences</a>
+<a id="nav-conf" href="%(siteurl)s/collection/Conferences" target="_blank">
+<span class="tooltip">Conferences<span class="tooltiptext">go to the New Conferences site</span></span></a>
 ::
 <a id="nav-jobs" href="%(siteurl)s/collection/Jobs" target="_blank">
 <span class="tooltip">Jobs<span class="tooltiptext">go to the New Jobs site</span></span></a>


### PR DESCRIPTION

show tooltip for labs conferences in navbar
take Conferences out of legacy site-map

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>