### PR TITLE
BibCheck: Clean one name authors

### DIFF
--- a/bibcheck/rules.cfg
+++ b/bibcheck/rules.cfg
@@ -178,3 +178,11 @@ check.replace = "INSPIRE-00278790"
 check = convert_grid_to_ror
 filter_collection = Institutions
 filter_pattern = 035:GRID
+
+[authoronename]
+check = regexp_replace
+filter_collection = HEP
+filter_pattern = 100__a:/,$/ or 700__a:/,$/
+check.find = "^([\\w'-]+)\\s?,$"
+check.replace = "\\1"
+check.fields = ["100__a", "700__a"]


### PR DESCRIPTION
    - Remove trailing comma from 100 and 700 fields in HEP

Signed-off-by: Melissa Clegg <cleggm1@fnal.gov>