### PR TITLE
BibExport: remove HEP from sitemap

### DIFF
--- a/bibexport/sitemap.cfg
+++ b/bibexport/sitemap.cfg
@@ -1,7 +1,5 @@
 [export_job]
 export_method = sitemap
-collection1 = HEP
-collection2 = HepNames
 collection3 = Institutions
 collection6 = Experiments
 collection7 = Journals

--- a/webstyle/robots.txt
+++ b/webstyle/robots.txt
@@ -25,6 +25,9 @@ Disallow: /record/merge
 Disallow: /info/manage
 Disallow: /batchuploader/metadata
 Disallow: /collection/Jobs Hidden
+Disallow: /collection/HEP
+Disallow: /collection/Jobs
+Disallow: /collection/Conferences
 
 User-Agent: bingbot
 Disallow: /cgi-bin/
@@ -52,6 +55,9 @@ Disallow: /record/merge
 Disallow: /info/manage
 Disallow: /batchuploader/metadata
 Disallow: /collection/Jobs Hidden
+Disallow: /collection/HEP
+Disallow: /collection/Jobs
+Disallow: /collection/Conferences
 
 User-Agent: Twitterbot
 Disallow: /cgi-bin/
@@ -79,6 +85,9 @@ Disallow: /record/merge
 Disallow: /info/manage
 Disallow: /batchuploader/metadata
 Disallow: /collection/Jobs Hidden
+Disallow: /collection/HEP
+Disallow: /collection/Jobs
+Disallow: /collection/Conferences
 
 User-agent: *
 Disallow: /cgi-bin/
@@ -108,5 +117,8 @@ Disallow: /record/merge
 Disallow: /info/manage
 Disallow: /batchuploader/metadata
 Disallow: /collection/Jobs Hidden
+Disallow: /collection/HEP
+Disallow: /collection/Jobs
+Disallow: /collection/Conferences
 
-Sitemap: http://inspirehep.net/sitemap-index.xml.gz
+Sitemap: http://old.inspirehep.net/sitemap-index.xml.gz


### PR DESCRIPTION
    * prepare for switch to new platform
    * remove HEP and HEPNames from sitemap
    * update robots.txt to use old.inspirehehp.net URL

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>