### PR TITLE
BibTaskLets: remove jobs/conf template check

### DIFF
--- a/bibtasklets/bst_check4template.py
+++ b/bibtasklets/bst_check4template.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2013, 2014, 2015 CERN.
+## Copyright (C) 2013, 2014, 2015, 2020 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -39,11 +39,9 @@ from invenio.bibedit_config import CFG_BIBEDIT_RECORD_TEMPLATES_PATH
 
 TEMPLATE_TYPES = {'HEP': ['HEP', 'article', 'book_chapter', 'book', 'thesis',
                           'conference_paper', 'preprint', 'proceedings'],
-                  'Conferences' : ['conference', 'conference'],
                   'HepNames' : ['hepnames', 'hepnames'],
                   'Experiments': ['experiment', 'experiment'],
                   'Institutions': ['institution', 'institution'],
-                  'Jobs': ['jobs', 'jobs'],
                   'Data': ['data', 'data_template']
                  }
 


### PR DESCRIPTION
    * 87fd734 removed the templates for Jobs and Conferences.
      No new records of this type should be created on legacy any longer.
      Existing records should not be edited on legacy any longer.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>