### PR TITLE
bst_consyn_harvest.py: add 'dis' as interesting doctype

### DIFF
--- a/bibtasklets/bst_consyn_harvest.py
+++ b/bibtasklets/bst_consyn_harvest.py
@@ -57,7 +57,7 @@ try:
 except ImportError:
     CFG_CONSYN_OUT_DIRECTORY = join(CFG_TMPSHAREDDIR, "consynharvest")
 
-INTERESTING_DOCTYPES = ['fla', 'add', 'chp', 'err', 'rev', 'sco', 'ssu', 'pub']
+INTERESTING_DOCTYPES = ['fla', 'add', 'chp', 'err', 'rev', 'sco', 'ssu', 'pub', 'dis']
 
 
 class StatusCodes(object):


### PR DESCRIPTION
* Adds 'dis' to INTERESTING_DOCTYPES such that also dis-cussions,
  i.e. paper of the type "Comment to ..." are included.

Signed-off-by: fschwenn <florian.schwennsen@desy.de>