### PR TITLE
BibExport: trim inst/exp from sitemap

### DIFF
--- a/bibexport/sitemap.cfg
+++ b/bibexport/sitemap.cfg
@@ -1,7 +1,5 @@
 [export_job]
 export_method = sitemap
-collection3 = Institutions
-collection6 = Experiments
 collection7 = Journals
 export_fulltext = 0
 


### PR DESCRIPTION
Institutions and Experiments are now available on labs and should be crawled there

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>